### PR TITLE
Bug fixed in vLLM Impl

### DIFF
--- a/vLLM/vllm/v1/worker/gpu_input_batch.py
+++ b/vLLM/vllm/v1/worker/gpu_input_batch.py
@@ -39,6 +39,8 @@ class CachedRequestState:
 
     lora_request: Optional[LoRARequest] = None
 
+    num_dropped_tokens: Optional[int] = 0
+
     def __post_init__(self):
         self.num_prompt_tokens = len(self.prompt_token_ids)
 
@@ -273,6 +275,7 @@ class InputBatch:
         self.num_tokens_no_spec[req_index] = request.num_tokens
 
         self.num_computed_tokens_cpu[req_index] = request.num_computed_tokens
+        self.num_dropped_tokens_list_cpu[req_index] = request.num_dropped_tokens
         self.block_table.add_row(request.block_ids, req_index)
 
         sampling_params = request.sampling_params
@@ -499,6 +502,8 @@ class InputBatch:
                 last_req_index]
             self.num_computed_tokens_cpu[
                 empty_index] = self.num_computed_tokens_cpu[last_req_index]
+            self.num_dropped_tokens_list_cpu[
+                empty_index] = self.num_dropped_tokens_list_cpu[last_req_index]
             self.block_table.move_row(last_req_index, empty_index)
             self.temperature_cpu[empty_index] = self.temperature_cpu[
                 last_req_index]

--- a/vLLM/vllm/v1/worker/gpu_model_runner.py
+++ b/vLLM/vllm/v1/worker/gpu_model_runner.py
@@ -398,7 +398,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
 
             # Update the cached states.
             num_computed_tokens = req_data.num_computed_tokens
+            num_dropped_tokens = req_data.num_dropped_tokens
+
             req_state.num_computed_tokens = num_computed_tokens
+            req_state.num_dropped_tokens = num_dropped_tokens
             # Add the sampled token(s) from the previous step (if any).
             # This doesn't include "unverified" tokens like spec decode tokens.
             num_new_tokens = (num_computed_tokens +
@@ -431,7 +434,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.input_batch.num_computed_tokens_cpu[req_index] = (
                 num_computed_tokens)
             self.input_batch.num_dropped_tokens_list_cpu[req_index] = (
-                req_data.num_dropped_tokens)
+                num_dropped_tokens)
             self.input_batch.should_compress_list[req_index] = \
                 req_data.should_compress
             self.input_batch.block_table.append_row(req_data.new_block_ids,

--- a/vLLM/vllm/v1/worker/gpu_model_runner.py
+++ b/vLLM/vllm/v1/worker/gpu_model_runner.py
@@ -239,10 +239,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             device=self.device)
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
-        self.arange_np = np.arange(max(self.max_num_reqs + 1,
-                                       self.max_model_len,
-                                       self.max_num_tokens),
-                                   dtype=np.int32)
+        self.arange_np = np.arange(self.max_model_len * self.max_num_reqs, dtype=np.int32)
         # NOTE(woosuk): These tensors are "stateless", i.e., they are literally
         # a faster version of creating a new tensor every time. Thus, we should
         # not make any assumptions about the values in these tensors.
@@ -267,9 +264,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                                             pin_memory=self.pin_memory)
         self.slot_mapping_np = self.slot_mapping_cpu.numpy()
         self.occupied_slot_mapping_cpu = torch.zeros(
-                                            max(self.max_num_reqs + 1,
-                                                self.max_model_len,
-                                                self.max_num_tokens),
+                                            self.max_model_len * self.max_num_reqs,
                                             dtype=torch.int32,
                                             device="cpu",
                                             pin_memory=self.pin_memory)


### PR DESCRIPTION
Thank you very much for your work on R-KV!

Over the past few days, I have been experimenting with the vLLM-based implementation. During this process, I observed inference errors occurring in both `batch_size = 1` and `batch_size > 1` settings.

After tracing through the vLLM execution and scheduling logic, I identified two issues that lead to these errors:
1. `num_dropped_tokens` state is not reset after inference completes. As a result, stale `num_dropped_tokens` values may leak into subsequent inference runs.
2. In the `batch_size > 1` case, `num_dropped_tokens` is not updated during batch condensation.
When some requests finish earlier than others, vLLM condenses the remaining requests to eliminate gaps via `self.input_batch.condense()`. During this process, metadata such as `num_computed_tokens` is correctly updated, but `num_dropped_tokens` is not. Consequently, before the next forward pass, `prepare_inputs` computes an incorrect `seq_len`, which diverges from the actual value and triggers downstream errors.

I have implemented a minimal fix for both issues in this PR. With these changes, R-KV now runs correctly on vLLM in my experiments.

Thank you again for your excellent work, and I hope this contribution is helpful to the community.