### PR TITLE
SGLang R-KV: validate data-parallel serving + refresh benchmark numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 ## 🔥 News
 
+- 🚀 [26/07/02] **The SGLang (v0.5.14) R-KV port is complete.** Decoding-time KV-cache compression with true physical eviction on the FlashInfer decode path, validated on Qwen2.5-Math-7B (H100): accuracy on par with the baseline (95% GSM8K), server-side batching (`eval.py --concurrency N`), and **plain data parallelism** (`DP=N ./launch_server.sh rkv 512`, throughput scales up to 5.2× on 8× H100). Code in `SGLang/rkv/` (`algo.py`, `integration.py`) plus the wiring patch `SGLang/patch/rkv-sglang-0.5.14.patch`; design/implementation notes in `SGLang/docs/DESIGN.md` and `SGLang/docs/IMPLEMENTATION.md`; benchmarks + reproduce steps in `SGLang/benchmark/` (`RESULTS_math7b.md`, `RESULTS_dp.md`, `RESULTS_a100_n100.md`).
 - ⚠️ [26/07/02] **If you computed GSM8K numbers with this repo before commit `e9f54c45`, please rerun them.** The shipped `data/gsm8k.jsonl` carried a stale `generation` field from an old experiment and `eval_math.py` preferred it over the fresh run's `output`, freezing GSM8K scores at ~40% regardless of method or budget (issues #26/#23). MATH and AIME24 were unaffected. All four serving integrations (vLLM, SGLang, Nano-vLLM, Mini-SGLang) plus the HuggingFace path are now GPU-validated on A100 with R-KV on/off — see `tests/smoke/` and `results/validation-2026-07-02-a100/`.
 - 🚀 [25/05/29] We are pleased to announce the release of **R-KV**, a highly efficient decoding time KV Cache compression method to serve reasoning Models.
 

--- a/SGLang/README.md
+++ b/SGLang/README.md
@@ -23,11 +23,16 @@ GSM8K-style math harness, first 20 items, **8 concurrent requests** (server-side
 | Config | Accuracy | KV compactions |
 | --- | --- | --- |
 | baseline (R-KV off) | 95% | — |
-| **R-KV, budget=512** | **95% (19/20)** | **188** |
+| **R-KV, budget=512** | **95% (19/20)** | **~235** |
 
-R-KV kept full accuracy while running **188 physical KV compactions with zero
+R-KV kept full accuracy while running **~235 physical KV compactions with zero
 crashes**, each shrinking a request from ~700+ tokens back to the 512-token
 budget. See [`benchmark/RESULTS_math7b.md`](benchmark/RESULTS_math7b.md).
+
+**Data parallel** (`DP=N ./benchmark/launch_server.sh rkv 512`, plain DP with
+`tp=1`) is validated: each replica runs its own R-KV over a disjoint request set,
+and throughput scales up to **5.2× on 8× H100** with unchanged accuracy — see
+[`benchmark/RESULTS_dp.md`](benchmark/RESULTS_dp.md).
 
 ---
 

--- a/SGLang/benchmark/RESULTS.md
+++ b/SGLang/benchmark/RESULTS.md
@@ -23,56 +23,59 @@ First measurements of the R-KV port, taken during phase-1 bring-up.
 ## Accuracy vs budget — Qwen2.5-Math-7B-Instruct (headline)
 
 Strong math model, so accuracy differences are signal, not noise. 20 items,
-few-shot prompt ~700 tokens, `window=8, buffer=16`, `max_new_tokens=512`.
+few-shot prompt ~700 tokens, `window=8, buffer=16`, `max_new_tokens=512`
+(re-run 2026-07-02, post rotary off-by-one fix).
 
 | Config | Accuracy (20) | Compactions | Notes |
 | --- | --- | --- | --- |
 | baseline (R-KV off) | 95% (19/20) | — | reference |
-| R-KV budget=512 | **100% (20/20)** | 184 | on par / +1, heavy eviction |
-| R-KV budget=256 | 90% (18/20) | 241 | most aggressive, slight drop |
+| R-KV budget=512 | **95% (19/20)** | ~230 | on par with baseline, heavy eviction |
+| R-KV budget=256 | **95% (19/20)** | 227 | most aggressive, still on par |
 
 **Headline takeaway.** Even though `budget=512 < prompt (~700)` — so R-KV evicts
-part of the few-shot prompt itself — accuracy is **fully preserved (100%)**,
-confirming the "keep important + recent" selection retains what matters. Only at
-`budget=256` does it dip (−5%). 184–241 physical compactions ran per sweep with
-the server never crashing.
+part of the few-shot prompt itself — accuracy is **identical to the baseline
+(95%)**, confirming the "keep important + recent" selection retains what matters.
+Even at `budget=256` there is **no drop**. ~227–230 physical compactions ran per
+sweep with the server never crashing. (Full report:
+[`RESULTS_math7b.md`](./RESULTS_math7b.md).)
 
 ## Accuracy vs budget — Qwen2.5-0.5B-Instruct (weak model, noisy)
 
+20 items (re-run 2026-07-02, post rotary off-by-one fix).
+
 | Config | Accuracy (20) | Compactions | Notes |
 | --- | --- | --- | --- |
-| baseline (R-KV off) | 35% (7/20) | — | reference |
-| R-KV budget=1024 | 35% (7/20) | ~0 | ≥ prompt+gen, almost no eviction ⇒ == baseline |
-| R-KV budget=512 | 40% (8/20) | 442 | heavy eviction, accuracy preserved |
-| R-KV budget=256 | 30% (6/20) | 482 | most aggressive, accuracy starts to drop |
+| baseline (R-KV off) | 30% (6/20) | — | reference |
+| R-KV budget=512 | 35% (7/20) | 386 | heavy eviction, accuracy preserved |
+| R-KV budget=256 | 35% (7/20) | 509 | most aggressive, still within noise |
 
-**Takeaway.** Accuracy is monotone and well-behaved in `budget`: at
-`budget ≥ 512` it matches the baseline within noise; only at `budget=256` does it
-start to degrade. This is exactly the expected behaviour of a KV compressor —
-lossless while the budget is large enough, lossy only when squeezed too hard.
-Crucially, the server ran **hundreds of physical compactions (freeing slots)
-without crashing**, confirming the eviction / free / `req_to_token` rewrite /
-rotary-decoupling are correct.
+**Takeaway.** On this weak *non-math* model the absolute accuracy is low and
+noisy (±5% per item), but R-KV is well-behaved: at both `budget=512` and
+`budget=256` it matches the baseline within noise (indeed marginally above).
+This is the expected behaviour of a KV compressor — lossless while the budget is
+large enough. Crucially, the server ran **hundreds of physical compactions
+(freeing slots) without crashing**, confirming the eviction / free /
+`req_to_token` rewrite / rotary-decoupling are correct.
 
-## Speed (fair, same eager config; serial batch=1)
+## Speed — Qwen2.5-0.5B-Instruct (fair, same eager config; serial batch=1)
 
-| Config | Wall (20) | avg tok | Throughput | Relative |
+| Config | Wall (20) | avg tok | Throughput | Notes |
 | --- | --- | --- | --- | --- |
-| baseline (CUDA graph, prod-like) | ~10s | 377 | ~750 tok/s | reference |
-| baseline (eager, fair) | 61s | 363 | **119 tok/s** | isolates CUDA-graph loss |
-| R-KV budget=512 | 81s | 366 | **90 tok/s** | 442 compactions |
-| R-KV budget=256 | 90s | 399 | **89 tok/s** | 482 compactions |
+| baseline (eager, fair) | 60.7s | 363 | **119.6 tok/s** | reference |
+| R-KV budget=512 | 72.3s | 320 | **88.6 tok/s** | 386 compactions |
+| R-KV budget=256 | 95.1s | 420 | **88.3 tok/s** | 509 compactions |
 
-**Two layers of cost:**
+**R-KV compaction overhead** (same eager path, only `--enable-rkv` differs):
+119.6 → 88.6 tok/s, **≈ 26% slower** — consistent with the Math-7B measurement
+(~28%). Source: every `buffer_size` steps R-KV reads back all layers' KV,
+computes an O(budget²) key-similarity, and relocates slots — all synchronous on
+the eager path.
 
-1. **R-KV compaction overhead** (same eager path, only `--enable-rkv` differs):
-   119 → 90 tok/s, **≈ 24% slower**. Source: every `buffer_size` steps R-KV
-   reads back all layers' KV, computes an O(budget²) key-similarity, and
-   relocates slots — all synchronous on the eager path.
-2. **Loss of CUDA graph** (implicit, larger): R-KV must run eager, while the
-   production baseline uses CUDA graph (~750 tok/s). So versus a *production*
-   baseline, most of the end-to-end slowdown comes from losing CUDA graph, not
-   from the compaction itself.
+**Loss of CUDA graph** (implicit, larger): R-KV must run eager, while a
+production baseline uses CUDA graph. So versus a *production* baseline, most of
+the end-to-end slowdown comes from losing CUDA graph, not from the compaction
+itself — see the Math-7B `concurrency=8` result (272 tok/s) for how batching
+amortizes the eager overhead.
 
 ## Caveat: this scenario is cost-only for R-KV
 

--- a/SGLang/benchmark/RESULTS_a100_n100.md
+++ b/SGLang/benchmark/RESULTS_a100_n100.md
@@ -41,10 +41,11 @@ this port against the repo's reference implementation before publishing.
    points). Even `budget=256` (≈ one quarter of the peak KV) loses only 2
    points. ~1000 physical compactions per sweep, zero crashes, no
    leak-checker aborts at idle.
-2. **The H100 n=20 numbers reproduce in trend, not in letter.** The n=20
-   "100% vs 95%" (serial) result was small-sample luck, as its own caveat
-   admitted; at n=100 the honest statement is *parity within noise* (90 vs
-   91).
+2. **The H100 n=20 numbers reproduce in trend, not in letter.** The original
+   pre-fix n=20 run showed an optimistic "100% vs 95%" (serial) that was
+   small-sample luck; the post-fix n=20 re-run is a flat 95% (see
+   [`RESULTS_math7b.md`](./RESULTS_math7b.md)), and at n=100 here the honest
+   statement is *parity within noise* (90 vs 91).
 3. **The rotary off-by-one fix does not change GSM8K accuracy** (89 → 90 is
    one item, well within noise) — consistent with a uniform +1 position shift
    of all decode tokens being nearly invisible to relative-position attention.

--- a/SGLang/benchmark/RESULTS_dp.md
+++ b/SGLang/benchmark/RESULTS_dp.md
@@ -1,0 +1,97 @@
+# R-KV under Data Parallelism (DP) — Correctness & Throughput
+
+How R-KV behaves under SGLang **plain data parallelism** (`--dp-size N`, `tp=1`):
+N independent replicas, each with its own KV pool and its own R-KV compressor,
+with a router load-balancing requests across them. Companion to
+[`RESULTS.md`](./RESULTS.md) / [`RESULTS_math7b.md`](./RESULTS_math7b.md).
+
+> **Verdict: plain DP works.** Each rank runs its own R-KV over a disjoint set of
+> requests — there is no cross-rank eviction-agreement problem (unlike TP, which
+> is still unsupported). Accuracy is unchanged vs single-GPU and throughput
+> scales strongly with the number of replicas.
+
+## Setup
+
+- **Model**: `Qwen2.5-Math-7B-Instruct` (bf16), single node, **8× NVIDIA H100 80GB**.
+- **R-KV**: `budget=512, window_size=8, buffer_size=16`; flags
+  `--disable-radix-cache --disable-decode-cuda-graph --disable-prefill-cuda-graph
+  --disable-overlap-schedule --page-size 1`, `--mem-fraction-static 0.85`.
+- **Parallelism**: `--dp-size N --tp-size 1` (plain DP; R-KV rejects `tp>1`).
+- **Dataset**: GSM8K-style few-shot MATH harness, `temperature=0`,
+  `max_new_tokens=512`, numeric judging (`eval.py`).
+- Date: 2026-07-02, post rotary off-by-one fix.
+
+## 1. Correctness — dp=2, first 20 items
+
+Validated against the five signals we use to distinguish "DP works" from "silent
+KV corruption":
+
+| Signal | Result |
+| --- | --- |
+| Launches, no crash | ✅ both `DP0` and `DP1` initialize + warm up |
+| Accuracy matches single-GPU | ✅ serial dp=2 = **19/20 (95%)**, identical to single-GPU |
+| Both ranks actually compress | ✅ `R-KV compacted` logged **independently on DP0 and DP1** |
+| No leak / crash at idle | ✅ `/health` OK, `token usage: 0.00` after drain, no leak assertion |
+| Output coherent (not garbage) | ✅ `avg_tokens ≈ 180 == baseline`; the one miss is a coherent wrong answer, not garbage |
+
+At `concurrency=16` the same dp=2 server scored 18/20 — a single item flipping vs
+the serial 19/20, which is ordinary batched-decode numerical noise (it happens on
+a single GPU too), not a DP defect. Physical KV length stayed pinned near `budget`
+(`#token ≈ 512`), confirming compaction fires on both ranks.
+
+## 2. Throughput scaling — dp ∈ {1, 2, 4, 8}
+
+128 items, `concurrency = dp × 16` (≈16 in-flight per replica), `budget=512`.
+
+| DP | GPUs | Concurrency | Accuracy (128) | avg tok | Wall | Throughput | vs dp=1 | Per-rank |
+| ---: | ---: | ---: | :---: | ---: | ---: | ---: | :---: | ---: |
+| 1 | 1 | 16 | 112/128 (87.5%) | 173 | 57.7s | 385.0 tok/s | 1.00× | 385 |
+| 2 | 2 | 32 | 113/128 (88.3%) | 171 | 30.9s | 709.1 tok/s | 1.84× | 355 |
+| 4 | 4 | 64 | 114/128 (89.1%) | 172 | 19.6s | 1125.8 tok/s | 2.92× | 281 |
+| 8 | 8 | 128 | 115/128 (89.8%) | 175 | 11.2s | **1997.1 tok/s** | **5.19×** | 250 |
+
+(Accuracy ~88% here vs 95% on the first-20 subset simply because n=128 spans
+harder items; it is **stable across all DP degrees**, which is the point.)
+
+**Findings:**
+
+- **Throughput scales strongly**: 385 → 709 → 1126 → 1997 tok/s, i.e. up to
+  **5.2× on 8 GPUs**. Each added replica is an independent R-KV instance, so the
+  compression overhead is fully parallelized.
+- **Scaling is sub-linear at high DP** (dp=8 = 5.2×, not 8×). This is a
+  *workload* artifact, not an R-KV one: with only 128 requests each dp=8 replica
+  handles ~16, so launch/warm-up/drain and router load imbalance (per-rank
+  compactions ranged 111–196) eat into the steady-state. A larger request stream
+  would push dp=8 closer to linear.
+- **Total compaction work is conserved**: every configuration ran ~1300 physical
+  compactions in total, just spread across ranks — dp does not change how much
+  R-KV work happens, only how it is parallelized.
+- **Every rank compresses, no errors/leaks** in any run; `avg_tokens` stayed
+  ~171–175 (coherent output, no runaway generations).
+
+## Scope / caveats
+
+- This is **plain data parallelism** (`--dp-size N --tp-size 1`). It works because
+  requests never cross ranks and each rank's R-KV is self-contained.
+- **DP attention** (`--enable-dp-attention`, which implies `tp>1`) is **not**
+  tested and is currently blocked by the `tp>1` startup guard; its
+  padded/gathered `forward_batch` layout has not been validated against R-KV's
+  hooks. See [`../docs/IMPLEMENTATION.md`](../docs/IMPLEMENTATION.md) §11.
+- **Tensor parallelism (`tp>1`) remains unsupported** (would silently corrupt the
+  KV cache without a cross-rank score all-reduce) and is rejected at startup.
+
+## Reproduce
+
+```bash
+cd SGLang/benchmark
+./prepare_data.sh
+
+# Launch a 4-way data-parallel R-KV server (budget=512):
+MODEL=/data/model/Qwen2.5-Math-7B-Instruct MEM_FRAC=0.85 DP=4 ./launch_server.sh rkv 512
+
+# Drive it with enough concurrency to fan out across all replicas:
+python3 eval.py --n 128 --concurrency 64 --label rkv7b_b512_dp4
+```
+
+`DP=N` on `launch_server.sh` adds `--dp-size N --tp-size 1`; `DP=1` (default) is
+the single-GPU path.

--- a/SGLang/benchmark/RESULTS_math7b.md
+++ b/SGLang/benchmark/RESULTS_math7b.md
@@ -20,45 +20,55 @@ differences are signal rather than noise. Companion to [`RESULTS.md`](./RESULTS.
   --disable-overlap-schedule --page-size 1`); the eager baseline uses the same
   flags without `--enable-rkv`. `window_size=8`, `buffer_size=16` throughout.
 
-> ⚠️ **Small sample (20 items).** Each item is ±5%, so 20/20 has some luck in it.
-> Re-run with `--n 100`+ for tighter figures. The trend, however, is clean.
+> ⚠️ **Small sample (20 items).** Each item is ±5%, so treat these as trend
+> indicators. Re-run with `--n 100`+ for tighter figures. The trend is clean.
+>
+> **Re-run 2026-07-02, post rotary off-by-one fix.** Earlier numbers (budget=512
+> 100%, budget=256 90%) were n=20 noise; with the fix accuracy is a flat 95% at
+> every budget — i.e. *identical* to the baseline. For a 5× larger sample on a
+> different GPU see [`RESULTS_a100_n100.md`](./RESULTS_a100_n100.md) (n=100,
+> A100: parity within noise, 90 vs 91).
 
 ## Accuracy vs budget
 
 | Config | Accuracy (20) | Compactions | avg tok | Notes |
 | --- | --- | --- | --- | --- |
 | baseline (R-KV off) | 95% (19/20) | — | 181 | reference |
-| **R-KV budget=512** | **100% (20/20)** | 184 | 156 | on par / +1, heavy eviction |
-| R-KV budget=256 | 90% (18/20) | 241 | 202 | most aggressive, slight drop |
+| **R-KV budget=512** | **95% (19/20)** | ~230 | 197 | on par with baseline, heavy eviction |
+| R-KV budget=256 | 95% (19/20) | 227 | 190 | most aggressive, still on par |
 
-**Takeaway.** Accuracy is monotone and, at a sensible budget, **lossless**:
+**Takeaway.** Accuracy is **lossless at every budget tested** — R-KV matches the
+baseline exactly (95%, 19/20):
 
-- At `budget=512` the model matches (indeed slightly beats, within noise) the
-  baseline — **even though `budget=512 < prompt (~700)`**, so R-KV is evicting
-  part of the few-shot prompt itself. The "keep important + recent" selection
-  retains the information that matters for the answer.
-- Only at the very aggressive `budget=256` does accuracy dip (−5%).
-- The server ran **184–241 physical compactions per sweep with zero crashes**,
+- At `budget=512` accuracy is identical to baseline — **even though
+  `budget=512 < prompt (~700)`**, so R-KV is evicting part of the few-shot prompt
+  itself. The "keep important + recent" selection retains what matters.
+- Even at the aggressive `budget=256` there is **no drop** (still 95%); the one
+  miss is the same item the baseline also misses.
+- The server ran **227–230 physical compactions per sweep with zero crashes**,
   confirming eviction / `free` / `req_to_token` rewrite / rotary decoupling are
   correct under sustained load on a 7B model.
 
-This is a much stronger signal than the 0.5B run: on a capable model the
-on/off gap is a clear, interpretable 0–5%, not noise.
+## Speed (fair, same eager config)
 
-## Speed (fair, same eager config; serial batch=1)
-
-| Config | Wall (20) | avg tok | Throughput | Relative |
+| Config | Wall (20) | avg tok | Throughput | Notes |
 | --- | --- | --- | --- | --- |
-| baseline (eager, fair) | 35s | 181 | ~103 tok/s | reference |
-| R-KV budget=512 | 41s | 156 | ~76 tok/s | 184 compactions |
-| R-KV budget=256 | 53s | 202 | ~76 tok/s | 241 compactions |
+| baseline (eager, fair) | 35.6s | 181 | 101.8 tok/s | serial batch=1, reference |
+| R-KV budget=512 | 53.4s | 197 | 73.7 tok/s | serial, ~230 compactions |
+| R-KV budget=256 | 49.1s | 190 | 77.3 tok/s | serial, 227 compactions |
+| R-KV budget=512, concurrency=8 | 14.3s | 194 | **272.2 tok/s** | 8 in-flight (batch path) |
 
 **R-KV compaction overhead** (same eager path, only `--enable-rkv` differs):
-≈103 → 76 tok/s, **~26% slower** — consistent with the 0.5B measurement (~24%).
-The overhead comes from the per-`buffer_size` compaction (read back all layers'
-KV, O(budget²) key-similarity, slot relocation), all synchronous on the eager
-path. As with 0.5B, the larger *implicit* cost is that R-KV must run eager and
-so gives up CUDA graph relative to a production baseline.
+≈102 → 74 tok/s at batch=1, **~28% slower** — consistent with the 0.5B
+measurement (~26%). The overhead comes from the per-`buffer_size` compaction
+(read back all layers' KV, O(budget²) key-similarity, slot relocation), all
+synchronous on the eager path.
+
+**Batching recovers it and then some.** At `concurrency=8`, R-KV budget=512
+sustains **272 tok/s** — ~2.7× the eager serial baseline and ~3.7× serial R-KV —
+because the batch>=2 per-request path amortizes the compaction work across
+in-flight requests. As with 0.5B, the larger *implicit* cost is that R-KV must
+run eager and so gives up CUDA graph relative to a production baseline.
 
 ## Caveat: benefit side not measured here
 
@@ -81,4 +91,7 @@ python3 eval.py --n 20 --label base7b
 # R-KV budget=512
 MODEL=/data/model/Qwen2.5-Math-7B-Instruct MEM_FRAC=0.85 ./launch_server.sh rkv 512
 python3 eval.py --n 20 --label rkv7b_b512
+
+# R-KV budget=512, batched (concurrency=8)
+python3 eval.py --n 20 --concurrency 8 --label rkv7b_b512_c8
 ```

--- a/SGLang/benchmark/launch_server.sh
+++ b/SGLang/benchmark/launch_server.sh
@@ -6,7 +6,12 @@
 #   ./launch_server.sh rkv 512                 # R-KV ON,  budget=512 (256/512/1024 ...)
 #   ./launch_server.sh baseline-cudagraph      # R-KV OFF, CUDA graph on (production-like)
 #
-# Env overrides: MODEL, PORT, WINDOW, BUFFER, MEM_FRAC
+# Data parallel (optional): set DP=N to run N R-KV replicas (plain DP, tp=1).
+# Each replica keeps its own KV pool and runs R-KV independently; a router
+# load-balances requests. Example:
+#   DP=4 ./launch_server.sh rkv 512            # 4-way data parallel, R-KV on
+#
+# Env overrides: MODEL, PORT, WINDOW, BUFFER, MEM_FRAC, DP
 set -euo pipefail
 
 MODE="${1:-rkv}"
@@ -16,6 +21,7 @@ PORT="${PORT:-30000}"
 WINDOW="${WINDOW:-8}"
 BUFFER="${BUFFER:-16}"
 MEM_FRAC="${MEM_FRAC:-0.6}"
+DP="${DP:-1}"
 
 # Locate the patched SGLang source produced by scripts/apply_rkv.sh.
 # Override with RKV_SGLANG_SRC=/path/to/sglang if you cloned it elsewhere.
@@ -38,16 +44,24 @@ RKV_FLAGS=(--disable-decode-cuda-graph --disable-prefill-cuda-graph
 COMMON=(--model-path "$MODEL" --attention-backend flashinfer
         --mem-fraction-static "$MEM_FRAC" --host 127.0.0.1 --port "$PORT")
 
+# Optional plain data parallelism: N independent R-KV replicas (tp=1). R-KV does
+# not support tp>1, but plain DP is fine -- each rank runs its own compressor
+# over a disjoint set of requests (validated; see RESULTS_dp.md).
+DP_FLAGS=()
+if [[ "$DP" -gt 1 ]]; then
+  DP_FLAGS=(--dp-size "$DP" --tp-size 1)
+fi
+
 case "$MODE" in
   rkv)
-    echo ">> R-KV ON  | budget=$BUDGET window=$WINDOW buffer=$BUFFER"
-    exec python3 -m sglang.launch_server "${COMMON[@]}" "${RKV_FLAGS[@]}" \
+    echo ">> R-KV ON  | budget=$BUDGET window=$WINDOW buffer=$BUFFER dp=$DP"
+    exec python3 -m sglang.launch_server "${COMMON[@]}" "${RKV_FLAGS[@]}" "${DP_FLAGS[@]}" \
       --enable-rkv \
       --rkv-config "{\"budget\":$BUDGET,\"window_size\":$WINDOW,\"buffer_size\":$BUFFER}"
     ;;
   baseline)
-    echo ">> BASELINE (eager, same flags as R-KV, no --enable-rkv)"
-    exec python3 -m sglang.launch_server "${COMMON[@]}" "${RKV_FLAGS[@]}"
+    echo ">> BASELINE (eager, same flags as R-KV, no --enable-rkv) dp=$DP"
+    exec python3 -m sglang.launch_server "${COMMON[@]}" "${RKV_FLAGS[@]}" "${DP_FLAGS[@]}"
     ;;
   baseline-cudagraph)
     echo ">> BASELINE (production-like: CUDA graph on)"

--- a/SGLang/docs/DESIGN.md
+++ b/SGLang/docs/DESIGN.md
@@ -207,9 +207,13 @@ adaptor), the lifecycle hook names (`on_request_begin/end`,
   armed request's own `seq_len`). Validated end-to-end on
   Qwen2.5-Math-7B-Instruct (FlashInfer, `budget=512`, 8 concurrent requests,
   decode `#running-req` up to 8): **19/20 = 95% accuracy** (== eager baseline),
-  **188 physical compactions**, no crashes. (`on_request_end` cleanup is
+  **~235 physical compactions** (2026-07-02 re-run, post rotary-fix), no crashes.
+  (`on_request_end` cleanup is
   **DONE**: wired in `batch_result_processor` beside `hisparse.request_finished`
   at the two real-finished points; verified per-request state clears to 0.)
+  Plain data parallelism (`--dp-size N --tp-size 1`) is also validated — each
+  rank runs its own R-KV; throughput scales up to 5.2× on 8× H100 (see
+  benchmark/RESULTS_dp.md). TP and dp-attention remain unsupported/untested.
 - **[LATER] Phase 2** — performance: avoid redundant read-back, optimize the
   O(budget²) similarity, CUDA-graph compatibility, reduce host/device syncs, and
   **TP ≥ 2 support** (cross-rank all-reduce of per-token scores; see

--- a/SGLang/docs/IMPLEMENTATION.md
+++ b/SGLang/docs/IMPLEMENTATION.md
@@ -105,9 +105,14 @@ Resolution:
   slot allocation and attention length automatically correct — new tokens append
   at the physical tail, attention reads exactly `budget (+n)` slots.
 - **Positions stay logical.** `override_decode_positions` sets
-  `positions[i] = len(origin_input_ids) + len(output_ids)` for each R-KV
-  request, overriding the physical-length-derived value. For an un-compacted
-  request this equals the normal value, so it is safe to always apply.
+  `positions[i] = len(origin_input_ids) + len(output_ids) - 1` for each R-KV
+  request, overriding the physical-length-derived value. The just-sampled token
+  is already appended to `output_ids` at forward time, so the count *minus one*
+  is the current token's 0-based rotary position; for an un-compacted request
+  this equals the baseline `clamp_position(seq_lens) = seq_lens - 1`, so it is
+  safe to always apply. (Omitting the `-1` was a bug fixed 2026-07-02 — it
+  rotated every R-KV decode token at position+1, leaving a one-slot gap between
+  the prompt and the generation; see §8.)
 
 Scheduler and ModelRunner share the process, so `Req` length fields are updated
 in place during compaction; the batch-level `seq_lens` tensor is updated by the
@@ -156,6 +161,19 @@ request occupying physical slots `slots = req_to_token[idx, :seq_len]`:
    a frozen dataclass built *before* `init_memory_pools` binds the compressor, so
    a snapshot field would capture `None`. Fix: look it up dynamically via
    `model_worker.model_runner.rkv_compressor` at the finished-request points.
+4. **Rotary off-by-one in `override_decode_positions` (owner review, 2026-07-02).**
+   The override used `len(origin_input_ids) + len(output_ids)`, but the
+   just-sampled token is already in `output_ids` at forward time, so every R-KV
+   decode token was rotated at `position + 1` (baseline is
+   `clamp_position(seq_lens) = seq_lens - 1`). Impact was small because RoPE is
+   relative — a uniform shift only leaves a single-position gap between the
+   prompt and the generation — so end-to-end output stayed coherent. Fix:
+   subtract 1 (see §5).
+5. **No startup validation of R-KV-incompatible flags (owner review, 2026-07-02).**
+   `--enable-rkv` silently corrupted the KV pool when combined with the radix
+   cache, a captured decode CUDA graph, overlap scheduling, `page_size > 1`, or
+   `tp > 1`. Fix: `ServerArgs._handle_rkv_validation` now rejects those combos at
+   startup with an explicit error.
 
 ## 9. Environment (dev-v0.5.14 needs a newer stack than v0.5.3-era wheels)
 
@@ -258,20 +276,22 @@ None of this exists today, so **`--tp 2` or higher will silently produce wrong
 results.** If TP is attempted before this is implemented, it should be hard-
 blocked in `server_args` (reject `enable_rkv && tp_size > 1`).
 
-### 11.3 Data parallel / dp-attention (DP ≥ 2) — unverified, no fundamental blocker
+### 11.3 Data parallel (DP ≥ 2)
 
-Under DP each rank serves a **disjoint set of requests** with its own KV pool;
-requests never cross ranks. So "each rank runs its own R-KV over its own
-requests" is self-consistent in principle — unlike TP there is **no cross-rank
-eviction-agreement problem**. What is missing is only:
+**Plain DP (`--dp-size N --tp-size 1`) — validated.** Under plain DP each rank
+serves a **disjoint set of requests** with its own KV pool; requests never cross
+ranks. So each rank runs its own R-KV over its own requests — unlike TP there is
+**no cross-rank eviction-agreement problem**. Verified 2026-07-02 on
+Qwen2.5-Math-7B (8× H100): every rank compresses independently, accuracy matches
+single-GPU, no leaks/crashes, and throughput scales up to **5.2× on 8 GPUs**. See
+[`../benchmark/RESULTS_dp.md`](../benchmark/RESULTS_dp.md).
 
-1. per-rank `batch > 1` already works (§11.1), but has only been validated in
-   the single-rank (`dp=1`) case;
-2. the dp-attention `forward_batch` layout (padded/scattered tokens, per-rank
-   `num_real_reqs`, all-gather of attention inputs) has **not been tested** with
-   R-KV's `observe` / `override_decode_positions` / `maybe_compact` hooks.
-
-Likely extends with modest work, but it is neither implemented nor tested.
+**DP attention (`--enable-dp-attention`) — still untested.** This mode makes
+attention data-parallel while MoE/FFN stay tensor-parallel (it implies `tp>1`,
+which the startup guard currently rejects). Its padded/scattered `forward_batch`
+layout (per-rank `num_real_reqs`, all-gather of attention inputs) has **not been
+tested** against R-KV's `observe` / `override_decode_positions` / `maybe_compact`
+hooks.
 
 ### Support matrix
 
@@ -280,10 +300,15 @@ Likely extends with modest work, but it is neither implemented nor tested.
 | `batch=1, tp=1, dp=1` | ✅ validated | — |
 | `batch > 1` (tp=1, dp=1) | ✅ supported | per-request triggering (method A) |
 | **TP ≥ 2** | ❌ **silently incorrect** | **missing cross-rank all-reduce of scores** (fundamental) |
-| DP ≥ 2 | ❌ untested | batch loop + dp-attention verification (no fundamental conflict) |
+| DP ≥ 2 (plain, `tp=1`) | ✅ validated | per-rank independent R-KV (see benchmark/RESULTS_dp.md) |
+| DP attention (`--enable-dp-attention`) | ❌ untested | implies tp>1 (blocked); padded forward_batch layout unverified |
 
-> **Recommendation:** until §11.2 is implemented, treat `--enable-rkv` as
-> incompatible with `--tp > 1`, and ideally reject that combination at startup.
+> **Enforced at startup:** `ServerArgs._handle_rkv_validation` rejects
+> `--enable-rkv` together with `--tp > 1` (and radix cache / decode CUDA graph /
+> overlap schedule / `page_size > 1`), so the silently-incorrect TP path cannot
+> be launched by accident. Plain DP (`--dp-size N --tp-size 1`) is allowed and
+> validated (§11.3); implementing the §11.2 cross-rank all-reduce is what would
+> lift the TP block.
 
 ## 12. Other limitations / next
 


### PR DESCRIPTION
## Summary

Extends the SGLang v0.5.14 R-KV port with **data-parallel (DP) serving support**
and refreshes all benchmark numbers to the **post-rotary-fix** state. Docs +
launcher + benchmarks only — **no changes to `rkv/` or the patch** (the rotary
off-by-one fix and `--enable-rkv` startup validation already shipped in
`cc4188b6`).

Work was developed and verified in `wanke1997/sglang-compress @ dev-v0.5.14`,
then ported into this repo's `SGLang/` tree.

## Data parallelism

- **`launch_server.sh`**: optional `DP=N` env → `--dp-size N --tp-size 1` (plain DP).
- **New `SGLang/benchmark/RESULTS_dp.md`**:
  - **Correctness (dp=2, n=20)**: serial 19/20 = 95%, identical to single-GPU;
    both ranks compress independently; no leaks/crashes; coherent output.
  - **Throughput scaling (n=128, budget=512, concurrency = dp×16)**:
    385 → 709 → 1126 → **1997 tok/s** for dp = 1/2/4/8, i.e. **up to 5.2× on
    8× H100**, accuracy unchanged.
- **`docs/IMPLEMENTATION.md`** §11.3 + support matrix: plain DP marked
  **validated**; DP-attention (`--enable-dp-attention`, implies `tp>1`) still
  untested; replaced the stale "should reject TP at startup" note with the now-
  enforced `_handle_rkv_validation` description.
- **`docs/DESIGN.md`** §9 + **`SGLang/README.md`**: DP status.

## Benchmark refresh (post rotary off-by-one fix, H100 n=20)

- **`RESULTS_math7b.md` / `RESULTS.md`**: Math-7B is a flat **95% (19/20)** at
  baseline, budget=512, and budget=256 — the earlier 100%/90% were n=20 noise.
  Added the `concurrency=8` row (272 tok/s); refreshed 0.5B numbers + compaction
  counts.
- **`docs/IMPLEMENTATION.md`** §5: corrected the `override_decode_positions`
  formula to `len(origin)+len(output)-1`; recorded the off-by-one + validation
  fixes in §8.
- **`RESULTS_a100_n100.md`**: reconciled the n=20 wording with the refreshed
  numbers (kept as the A100 n=100 record).

## Root README

- Added a **News** entry announcing the completed SGLang port (DP, concurrency,
  95% GSM8K) with paths to code, docs, and benchmarks.

## Validation

- DP correctness + throughput sweeps run on 8× H100 (Qwen2.5-Math-7B); every
  rank compresses independently, no errors/leaks in any server log.
- `launch_server.sh` syntax-checked (`bash -n`).

## Notes / scope

- **Plain DP only** (`--dp-size N --tp-size 1`). DP-attention and TP (`tp>1`)
  remain unsupported — `tp>1` is rejected at startup.
- Left the pre-existing `R-KV/benchmark` path token in the older benchmark docs
  untouched (out of scope); the new `RESULTS_dp.md` uses correct `SGLang/`-relative paths.