### PR TITLE
docs(sglang): fix stale relative links and path tokens

### DIFF
--- a/SGLang/benchmark/RESULTS.md
+++ b/SGLang/benchmark/RESULTS.md
@@ -89,5 +89,5 @@ R-KV pays off when:
   concurrent requests, raising aggregate throughput.
 
 A long-sequence / memory-pressure throughput test is needed to show the benefit
-side. Phase-2 perf targets (see `R-KV/doc/DESIGN.md`): CUDA-graph-compatible compaction,
+side. Phase-2 perf targets (see `SGLang/docs/DESIGN.md`): CUDA-graph-compatible compaction,
 a cheaper redundancy estimate than O(budget²), and avoiding full KV read-back.

--- a/SGLang/benchmark/RESULTS_math7b.md
+++ b/SGLang/benchmark/RESULTS_math7b.md
@@ -81,7 +81,7 @@ still needed to show the upside.
 ## Reproduce
 
 ```bash
-cd R-KV/benchmark
+cd SGLang/benchmark
 ./prepare_data.sh   # or use an existing test.jsonl via --data
 
 # baseline (eager)

--- a/SGLang/docs/IMPLEMENTATION.md
+++ b/SGLang/docs/IMPLEMENTATION.md
@@ -18,8 +18,8 @@ The port is split into two layers:
 
 | Layer | File | Responsibility |
 | --- | --- | --- |
-| **Algorithm** | [`algo.py`](./algo.py) | Pure, device-agnostic R-KV scoring & selection. Zero SGLang deps. CPU-testable. |
-| **Integration** | [`integration.py`](./integration.py) | Bridges the algorithm to SGLang's paged KV pool, FlashInfer decode path, and scheduler lifecycle. |
+| **Algorithm** | [`algo.py`](../rkv/algo.py) | Pure, device-agnostic R-KV scoring & selection. Zero SGLang deps. CPU-testable. |
+| **Integration** | [`integration.py`](../rkv/integration.py) | Bridges the algorithm to SGLang's paged KV pool, FlashInfer decode path, and scheduler lifecycle. |
 
 Phase-1 scope: **FlashInfer backend, `page_size=1`, correctness first.**
 `batch >= 1` is supported via **per-request triggering** (each request decides


### PR DESCRIPTION
The SGLang docs were carried over from sglang-compress (which lays the port out under R-KV/); a few path references never got repointed to this repo's SGLang/ layout:

- docs/IMPLEMENTATION.md: the [algo.py]/[integration.py] table links pointed at ./algo.py / ./integration.py (docs/ dir) instead of ../rkv/.
- benchmark/RESULTS_math7b.md: 'cd R-KV/benchmark' -> 'cd SGLang/benchmark'.
- benchmark/RESULTS.md: 'see R-KV/doc/DESIGN.md' -> 'SGLang/docs/DESIGN.md'.

Verified: all markdown links across SGLang/*.md now resolve (relative targets + in-page anchors), and no R-KV/ path tokens remain.