### PR TITLE
ci/docs: fix stale Mini-SGLang test path after port restructure

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Byte-compile the R-KV integration sources
         run: |
           python -m compileall -q HuggingFace/rkv Nano-vLLM/nanovllm \
-            Mini-SGLang/python/minisgl tests/smoke
+            Mini-SGLang/rkv tests/smoke
       - name: Nano-vLLM R-KV algorithm tests
         run: python Nano-vLLM/tests/test_rkv_algorithm.py
       - name: Mini-SGLang R-KV algorithm + integration tests
-        run: PYTHONPATH=Mini-SGLang/python python Mini-SGLang/tests/misc/test_rkv_algorithm.py
+        run: python Mini-SGLang/tests/test_rkv_algorithm.py
       - name: SGLang R-KV algorithm / integration / cross-repo parity tests
         run: |
           python SGLang/tests/test_rkv_algo.py

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ python Nano-vLLM/tests/test_rkv_algorithm.py
 
 # Mini-SGLang port — same algorithm tests plus disabled-compressor /
 # drop_request / drain_pending_free_slots integration coverage.
-PYTHONPATH=Mini-SGLang/python python Mini-SGLang/tests/misc/test_rkv_algorithm.py
+python Mini-SGLang/tests/test_rkv_algorithm.py
 
 # SGLang port — algorithm parity, compaction/lifecycle/batch integration, and
 # cross-repo bit-level parity against this repo's rkv/ reference.


### PR DESCRIPTION
The port restructure moved the CPU test tests/misc/test_rkv_algorithm.py -> tests/test_rkv_algorithm.py and removed the vendored python/minisgl tree (the test now loads rkv/ by path, no PYTHONPATH needed). Update the references that still pointed at the old location:

- .github/workflows/cpu-tests.yml: byte-compile Mini-SGLang/rkv (not python/minisgl); run 'python Mini-SGLang/tests/test_rkv_algorithm.py'.
- README.md Tests section: same command.

Verified both from the repo root (compileall + test pass).