### PR TITLE
tests/smoke: repair sglang + mini-sglang smokes for the restructured ports

### DIFF
--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -16,8 +16,8 @@ Python 3.10, at repo `main`:
 |---|---|---|---|
 | `vllm_smoke.py` | `pip install vllm==0.8.5 transformers==4.51.3`, then overlay the whole checked-in `vLLM/vllm/` package onto site-packages | Qwen/Qwen3-0.6B | `VLLM_USE_V1=1 VLLM_V1_R_KV_BUDGET=64 VLLM_V1_R_KV_BUFFER=8` (`BUFFER=0` disables; backend must be FLASH_ATTN) |
 | `nano_smoke.py` | `pip install -e Nano-vLLM` + flash-attn>=2.5 (model path must be a **local directory**) | Qwen/Qwen3-0.6B | `RKV_ON=1` -> `rkv_enabled=True, rkv_budget=256, rkv_buffer=32` |
-| `minisgl_smoke.py` | `pip install -e Mini-SGLang` | Qwen/Qwen3-0.6B | `RKV_ON=1` -> `rkv_enabled=True, rkv_budget=512, rkv_buffer=64`; instruments `RKVCompressor.maybe_compress` and fails if compression never fires |
-| `sglang_smoke.py` | `pip install -r SGLang/requirements-rkv.txt && pip install -e SGLang/python --no-build-isolation` | Qwen/Qwen2.5-0.5B-Instruct | `RKV_ON=1` -> `compress_algorithm="RKV"`, triton backend, cuda graph off; `BATCH=2` for the batch variant |
+| `minisgl_smoke.py` | `cd Mini-SGLang && scripts/apply_rkv.sh`, then `pip install -e mini-sglang-src` | Qwen/Qwen3-0.6B | `RKV_ON=1` -> `rkv_enabled=True, rkv_budget=512, rkv_buffer=64`; instruments `RKVCompressor.maybe_compress` and fails if compression never fires |
+| `sglang_smoke.py` | `cd SGLang && scripts/apply_rkv.sh`, then `pip install -r requirements-rkv.txt && pip install -e sglang-src/python` | Qwen/Qwen2.5-0.5B-Instruct | `RKV_ON=1` -> `enable_rkv=True, rkv_budget=128`, FlashInfer, radix/cuda-graph/overlap off, `page_size=1`; `BATCH=2` for the batch variant |
 | `hf_smoke.py` | `pip install -e HuggingFace` + flash-attn (transformers must be `>=4.48.1,<4.56`) | deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | `MODE=rkv` (monkeypatch) vs `MODE=fullkv` (stock forward) |
 
 Usage examples:

--- a/tests/smoke/minisgl_smoke.py
+++ b/tests/smoke/minisgl_smoke.py
@@ -12,7 +12,7 @@ from health_check import report
 MODEL = os.environ.get("RKV_SMOKE_MODEL", "Qwen/Qwen3-0.6B")
 RKV_ON = os.environ.get("RKV_ON", "1") == "1"
 
-from minisgl.compress.integration import RKVCompressor  # noqa: E402
+from minisgl.rkv.integration import RKVCompressor  # noqa: E402
 from minisgl.core import SamplingParams  # noqa: E402
 from minisgl.llm import LLM  # noqa: E402
 

--- a/tests/smoke/sglang_smoke.py
+++ b/tests/smoke/sglang_smoke.py
@@ -1,5 +1,6 @@
-"""SGLang (0.4.3.post1 fork) R-KV smoke: Qwen2.5-0.5B-Instruct,
-triton backend, cuda graph off. Toggle with RKV_ON=0/1; BATCH=1/2.
+"""SGLang (v0.5.14 port) R-KV smoke: Qwen2.5-0.5B-Instruct, FlashInfer
+backend, eager decode. R-KV requires radix cache / cuda graph / overlap off and
+page_size=1 (enforced at startup). Toggle with RKV_ON=0/1; BATCH=1/2.
 Needs a __main__ guard: sglang launches subprocesses via mp spawn."""
 import os
 import sys
@@ -22,17 +23,21 @@ def main():
     kwargs = dict(
         model_path=MODEL,
         dtype="bfloat16",
-        attention_backend="triton",
+        attention_backend="flashinfer",
         mem_fraction_static=0.25,
         disable_cuda_graph=True,
+        # R-KV frees KV slots mid-generation; these are required (enforced by
+        # the port's ServerArgs validation) and eager-only.
+        disable_radix_cache=True,
+        disable_overlap_schedule=True,
+        page_size=1,
     )
     if RKV_ON:
         kwargs.update(
-            compress_algorithm="RKV",
-            compress_max_window=8,
-            compress_max_prompt=32,
-            compress_divide_length=16,
-            compress_divide_method="step_length",
+            enable_rkv=True,
+            rkv_budget=128,
+            rkv_window_size=8,
+            rkv_buffer_size=16,
         )
 
     t0 = time.time()
@@ -41,7 +46,7 @@ def main():
 
     prompts = [PROMPT] * BATCH
     t0 = time.time()
-    outputs = llm.generate(prompts, {"temperature": 0, "max_new_tokens": 128})
+    outputs = llm.generate(prompts, {"temperature": 0, "max_new_tokens": 256})
     gen_s = time.time() - t0
 
     if isinstance(outputs, dict):


### PR DESCRIPTION
Both smokes were stale after the SGLang/Mini-SGLang restructures and failed to import/run against current main:

- minisgl_smoke.py: import minisgl.compress -> minisgl.rkv (package renamed).
- sglang_smoke.py: rewrite from the old v0.4.3 fork API (compress_algorithm="RKV", triton) to the v0.5.14 port API (enable_rkv + rkv_budget/window/buffer, FlashInfer, radix/cuda-graph/overlap off, page_size=1).
- README: fix install steps (apply_rkv.sh + pip install -e {mini-sglang-src, sglang-src/python}) and the R-KV switch descriptions.

Verified on H100 (Qwen2.5-0.5B):
  MINISGL: RKV_ON=1 PASS (384 compress calls, healthy) + RKV_ON=0 PASS SGLANG:  RKV_ON=1 batch=1 & batch=2 PASS + RKV_ON=0 PASS