### PR TITLE
SGLang: port hardened R-KV (prefill, fused kernel, CUDA-graph, tensor parallelism, runtime-safety)

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -32,6 +32,7 @@ jobs:
           python SGLang/tests/test_rkv_integration.py
           python SGLang/tests/test_rkv_prefill.py
           python SGLang/tests/test_rkv_prefill_integration.py
+          python SGLang/tests/test_rkv_redundancy_fused.py
           python SGLang/tests/test_cross_repo_parity.py
       - name: FlashInfer R-KV algorithm + adapter + cross-repo parity tests
         run: |

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -14,8 +14,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Install CPU torch
-        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+      - name: Install CPU torch + test deps
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install numpy msgspec
       - name: Byte-compile the R-KV integration sources
         run: |
           python -m compileall -q HuggingFace/rkv Nano-vLLM/nanovllm \
@@ -28,6 +30,8 @@ jobs:
         run: |
           python SGLang/tests/test_rkv_algo.py
           python SGLang/tests/test_rkv_integration.py
+          python SGLang/tests/test_rkv_prefill.py
+          python SGLang/tests/test_rkv_prefill_integration.py
           python SGLang/tests/test_cross_repo_parity.py
       - name: FlashInfer R-KV algorithm + adapter + cross-repo parity tests
         run: |

--- a/SGLang/README.md
+++ b/SGLang/README.md
@@ -83,10 +83,10 @@ support**, two-phase compaction, and full KV-pool memory accounting (see
 2. **Startup validation** (`server_args.py`, `_handle_rkv_validation`):
    `--enable-rkv` rejects configurations the port's memory safety depends on but
    previously did not enforce (radix cache on, overlap schedule on,
-   `page_size > 1`, `tp_size > 1`) instead of silently corrupting the KV pool;
-   plus `RKVConfig` guard checks (`buffer_size >= window_size`,
-   `min_seq_len >= budget`). (Decode CUDA graph was **later made compatible** and
-   is no longer rejected.)
+   `page_size > 1`) instead of silently corrupting the KV pool; plus `RKVConfig`
+   guard checks (`buffer_size >= window_size`, `min_seq_len >= budget`). (Decode
+   CUDA graph was **later made compatible** and is no longer rejected;
+   **tensor parallelism was later implemented** — see the support matrix.)
 
 ---
 
@@ -283,9 +283,9 @@ server configuration (all set for you by `launch_server.sh`):
 | --- | --- |
 | `batch = 1`, `tp = 1`, `dp = 1` | ✅ validated |
 | `batch > 1` (`tp = 1`, `dp = 1`) | ✅ validated (per-request triggering) |
-| Tensor parallel (`tp ≥ 2`) | ❌ **not supported — silently incorrect** without a cross-rank score all-reduce (see [`docs/IMPLEMENTATION.md`](docs/IMPLEMENTATION.md) §11.2). Do not combine `--enable-rkv` with `--tp > 1`. |
+| Tensor parallel (`tp ≥ 2`) | ✅ supported — the per-token eviction score is all-reduced across the attention-TP group before top-k, so every rank evicts the identical tokens (see [`docs/IMPLEMENTATION.md`](docs/IMPLEMENTATION.md) §11.2); validated on 8× H100 |
 | Data parallel — plain (`dp ≥ 2`, `tp = 1`) | ✅ validated — each replica runs its own R-KV over a disjoint request set; throughput scales up to 5.2× on 8× H100 (see [`benchmark/RESULTS_dp.md`](benchmark/RESULTS_dp.md)) |
-| DP attention (`--enable-dp-attention`) | ❌ untested — implies `tp > 1` (currently blocked at startup); padded `forward_batch` layout unverified |
+| DP attention (`--enable-dp-attention`) | ❌ unsupported — padded `forward_batch` layout unverified against the R-KV hooks |
 | CUDA-graph decode | ✅ supported (in-graph observation + hybrid eager compaction steps) |
 
 ---

--- a/SGLang/README.md
+++ b/SGLang/README.md
@@ -63,8 +63,12 @@ implementation before being published here:
   4.1× throughput. Details:
   [`benchmark/RESULTS_a100_n100.md`](benchmark/RESULTS_a100_n100.md).
 
-Two correctness fixes found during verification are included here on top of
-the ported source (`wanke1997/sglang-compress` @ `9ed5f084`):
+This distribution tracks the hardened R-KV source (upstream fork
+`wanke1997/sglang-compress`); two correctness fixes found during the original
+verification (below) are now baked into the source, along with substantial later
+work — prefill-phase R-KV, a fused Triton redundancy kernel, **decode CUDA-graph
+support**, two-phase compaction, and full KV-pool memory accounting (see
+[`docs/OPTIMIZATIONS.md`](docs/OPTIMIZATIONS.md)).
 
 1. **Rotary position off-by-one** (`rkv/integration.py`,
    `override_decode_positions`): the override used
@@ -76,24 +80,24 @@ the ported source (`wanke1997/sglang-compress` @ `9ed5f084`):
    decode step — a uniform shift that measurably did not hurt GSM8K accuracy
    (89 vs 90 at n=100), but made `--enable-rkv` non-equivalent to baseline
    even before any compression fires.
-2. **Startup validation** (in the wiring patch, `server_args.py`,
-   `_handle_rkv_validation`): `--enable-rkv` now rejects configurations the
-   port's memory safety depends on but previously did not enforce (radix
-   cache on, decode CUDA graph on, overlap schedule on, `page_size > 1`,
-   `tp_size > 1`) instead of silently corrupting the KV pool; plus
-   `RKVConfig` guard asserts (`buffer_size >= window_size`,
-   `min_seq_len >= budget`) and docstring corrections.
+2. **Startup validation** (`server_args.py`, `_handle_rkv_validation`):
+   `--enable-rkv` rejects configurations the port's memory safety depends on but
+   previously did not enforce (radix cache on, overlap schedule on,
+   `page_size > 1`, `tp_size > 1`) instead of silently corrupting the KV pool;
+   plus `RKVConfig` guard checks (`buffer_size >= window_size`,
+   `min_seq_len >= budget`). (Decode CUDA graph was **later made compatible** and
+   is no longer rejected.)
 
 ---
 
 ## Why a patch, not a fork?
 
-R-KV touches SGLang in a **tiny, purely additive** way: one self-contained
-package (`rkv/`) plus ~137 lines of wiring across **5** existing files. Instead
+R-KV touches SGLang in a **small, purely additive** way: one self-contained
+package (`rkv/`) plus ~780 lines of wiring across **9** existing files. Instead
 of vendoring the entire (~6700-file) SGLang tree, this directory ships:
 
 - `rkv/` — the R-KV code (browsable, the source of truth);
-- `patch/` — the 5-file wiring diff;
+- `patch/` — the 9-file wiring diff;
 - `scripts/apply_rkv.sh` — clones the **exact pinned** SGLang commit, drops in
   `rkv/`, and applies the patch.
 
@@ -104,12 +108,12 @@ upstream commit.
 SGLang/
 ├── README.md                      # you are here
 ├── requirements-rkv.txt           # pinned, verified dependency stack
-├── rkv/                           # R-KV package (algo.py, integration.py)
-├── patch/rkv-sglang-0.5.14.patch  # wiring diff (5 upstream files)
+├── rkv/                           # R-KV package (algo, integration, prefill, redundancy_fused)
+├── patch/rkv-sglang-0.5.14.patch  # wiring diff (9 upstream files)
 ├── scripts/apply_rkv.sh           # clone pinned SGLang + drop in rkv/ + apply patch
 ├── benchmark/                     # eval.py, launch_server.sh, prepare_data.sh, data/, RESULTS*.md
-├── docs/                          # DESIGN.md, IMPLEMENTATION.md (deep-dive)
-└── tests/                         # GPU-free CPU unit tests
+├── docs/                          # DESIGN, IMPLEMENTATION, OPTIMIZATIONS, REPRODUCE
+└── tests/                         # GPU-free CPU unit tests (+ fused-kernel GPU test)
 ```
 
 ---
@@ -171,12 +175,16 @@ pip install -r requirements-rkv.txt \
 
 ### Step 3 — Smoke test (no GPU needed)
 
-The algorithm and integration logic have GPU-free CPU unit tests:
+The algorithm and integration logic have GPU-free CPU unit tests (the fused-kernel
+test needs a GPU + Triton and self-skips otherwise):
 
 ```bash
-python3 tests/test_rkv_algo.py           # 4 tests — algorithm parity vs reference
-python3 tests/test_rkv_integration.py    # 9 tests — compaction, lifecycle, batch>=2
-python3 tests/test_cross_repo_parity.py  # bit-level parity vs this repo's rkv/ reference
+python3 tests/test_rkv_algo.py                 #  7 tests — algorithm parity vs reference
+python3 tests/test_rkv_integration.py          # 24 tests — compaction, lifecycle, memory, batch>=2
+python3 tests/test_rkv_prefill.py              #  9 tests — prefill algorithm (oneshot/buffered)
+python3 tests/test_rkv_prefill_integration.py  # 11 tests — prefill compaction & admission
+python3 tests/test_rkv_redundancy_fused.py     # 11 tests — fused Triton redundancy kernel (GPU)
+python3 tests/test_cross_repo_parity.py        # bit-level parity vs this repo's rkv/ reference
 ```
 
 All should print `OK` / `ALL PARITY CHECKS PASSED`.
@@ -233,13 +241,19 @@ mirror the R-KV reference); a `--rkv-config` JSON string **overrides** the flags
 | `--rkv-buffer-size` | `128` | compress every N newly generated tokens per request |
 | `--rkv-min-seq-len` | `budget` | min KV length before compression is considered |
 | `--rkv-config` | — | JSON that overrides any of the above, e.g. `'{"budget":512,"buffer_size":16}'` |
+| `--rkv-max-active-requests` | — | cap concurrent R-KV requests → shrinks the `rolling_q` observation buffer (trades peak concurrency for memory) |
+| `--rkv-fused-validation` | `startup` | when to validate the fused redundancy kernel: `startup` / `first-request` / `off` |
 
-Example:
+Prompt-phase compression is a separate mode: `--enable-rkv-prefill` (+
+`--rkv-prefill-config` JSON, `mode` = `oneshot` or `buffered`). It cannot combine
+with `--enable-rkv` and additionally requires `--disable-prefill-cuda-graph`.
+
+Example (decode R-KV, CUDA-graph decode left **on** — now supported):
 
 ```bash
 python3 -m sglang.launch_server --model-path <model> \
   --attention-backend flashinfer \
-  --disable-decode-cuda-graph --disable-prefill-cuda-graph \
+  --disable-prefill-cuda-graph \
   --disable-overlap-schedule --disable-radix-cache --page-size 1 \
   --enable-rkv --rkv-budget 512 --rkv-buffer-size 16
 ```
@@ -254,9 +268,12 @@ server configuration (all set for you by `launch_server.sh`):
 - `--disable-radix-cache` — R-KV frees KV slots the radix/prefix cache would
   still reference; leaving it on double-counts the pool and crashes the leak
   checker. Prefix reuse assumes KV is immutable; R-KV evicts it.
-- `--disable-decode-cuda-graph --disable-prefill-cuda-graph` — dynamic eviction
-  cannot live inside a captured CUDA graph, so R-KV runs eager.
-- `--disable-overlap-schedule` — simpler, deterministic timing for phase 1.
+- **Decode CUDA graph is supported** and left on (the observation-window queries
+  are collected inside the captured graph, with a hybrid eager path only for the
+  compaction steps). `--enable-rkv-prefill` additionally requires
+  `--disable-prefill-cuda-graph` (prompt-phase scoring is dynamic-shape).
+- `--disable-overlap-schedule` — simpler, deterministic timing, and it avoids an
+  allocator free-list race during compaction (see [`docs/OPTIMIZATIONS.md`](docs/OPTIMIZATIONS.md) §2.2/§3).
 - `--page-size 1` — clean per-slot `free()` (the paged allocator frees at page
   granularity otherwise).
 
@@ -269,7 +286,7 @@ server configuration (all set for you by `launch_server.sh`):
 | Tensor parallel (`tp ≥ 2`) | ❌ **not supported — silently incorrect** without a cross-rank score all-reduce (see [`docs/IMPLEMENTATION.md`](docs/IMPLEMENTATION.md) §11.2). Do not combine `--enable-rkv` with `--tp > 1`. |
 | Data parallel — plain (`dp ≥ 2`, `tp = 1`) | ✅ validated — each replica runs its own R-KV over a disjoint request set; throughput scales up to 5.2× on 8× H100 (see [`benchmark/RESULTS_dp.md`](benchmark/RESULTS_dp.md)) |
 | DP attention (`--enable-dp-attention`) | ❌ untested — implies `tp > 1` (currently blocked at startup); padded `forward_batch` layout unverified |
-| CUDA-graph decode | ❌ eager only (phase 1) |
+| CUDA-graph decode | ✅ supported (in-graph observation + hybrid eager compaction steps) |
 
 ---
 
@@ -278,7 +295,10 @@ server configuration (all set for you by `launch_server.sh`):
 - [`docs/DESIGN.md`](docs/DESIGN.md) — architecture, the paged-pool tension, the
   rotary/position scheme, and why the `sparsity/` framework was not reused.
 - [`docs/IMPLEMENTATION.md`](docs/IMPLEMENTATION.md) — the practical code map:
-  wiring points, bring-up bugs, and the parallelism/batching support matrix.
+  the 9 wiring points, bring-up bugs, and the parallelism/batching support matrix.
+- [`docs/OPTIMIZATIONS.md`](docs/OPTIMIZATIONS.md) — performance optimizations and
+  production-hardening (CUDA graph, fused kernel, two-phase compaction, admission).
+- [`docs/REPRODUCE.md`](docs/REPRODUCE.md) — exact, validated reproduction & usage.
 - [`benchmark/RESULTS.md`](benchmark/RESULTS.md) — Qwen2.5-0.5B sanity numbers.
 - [`benchmark/RESULTS_math7b.md`](benchmark/RESULTS_math7b.md) — Math-7B results.
 

--- a/SGLang/benchmark/launch_server.sh
+++ b/SGLang/benchmark/launch_server.sh
@@ -35,9 +35,13 @@ fi
 export PYTHONPATH="$SGLANG_SRC/python"
 export HF_HUB_DISABLE_XET=1  # HF Xet transfer can hang on large files
 
-# R-KV requires: eager decode (no captured CUDA graph), radix/prefix cache OFF
-# (R-KV frees slots the radix tree still references -> pool double-count crash),
-# overlap OFF (simple timing), page_size=1 (clean per-slot free).
+# R-KV requires: radix/prefix cache OFF (R-KV frees slots the radix tree still
+# references -> pool double-count crash), overlap OFF (avoids an allocator
+# free-list race during compaction), page_size=1 (clean per-slot free).
+# NOTE: decode CUDA graph is now SUPPORTED (in-graph observation + hybrid eager
+# compaction steps). This harness keeps it eager (--disable-decode-cuda-graph)
+# only for a bit-reproducible baseline; drop that flag to run with the graph on
+# (faster). Prefill graph stays off.
 RKV_FLAGS=(--disable-decode-cuda-graph --disable-prefill-cuda-graph
            --disable-overlap-schedule --disable-radix-cache --page-size 1)
 

--- a/SGLang/docs/DESIGN.md
+++ b/SGLang/docs/DESIGN.md
@@ -5,6 +5,13 @@ the R-KV port. It captures the architecture research and design decisions that
 are **not** obvious from the code alone. Read this first before touching the
 integration layer.
 
+> **Scope: decode-time R-KV.** This doc covers the original *decoding-time* R-KV
+> (`--enable-rkv`). R-KV also has a **prefill-time** mode (`--enable-rkv-prefill`,
+> code in [`prefill.py`](../rkv/prefill.py) /
+> [`prefill_integration.py`](../rkv/prefill_integration.py));
+> its design, results and roadmap are in
+> [`FINDINGS_AND_ROADMAP.md`](./OPTIMIZATIONS.md).
+
 ## 1. Goal
 
 Port **R-KV** (Redundancy-aware KV Cache Compression for reasoning models,
@@ -17,15 +24,23 @@ tokens, giving large memory savings and throughput gains at near-full accuracy.
 `rkv/compression/r1_kv.py` (+ `rkv/utils.py`). We port that faithfully rather
 than reworking a previous (buggy, slow) integration.
 
-## 2. Branch layout (repo: wanke1997/sglang-compress)
+## 2. Where this port comes from
 
-| Branch | Purpose |
-| --- | --- |
-| `dev-v0.5.14` | Active development. Clean SGLang v0.5.14 baseline + this port. |
-| `release/sglang-v0.5.14` | Pristine v0.5.14 reference. **Do not modify.** |
-| `dev` / `main` | Old CustomKV/SnapKV implementation on SGLang v0.4.3 (buggy + slow). Kept only for reference. |
+This directory is a **patch-style distribution**: it does not vendor SGLang.
+Instead it ships the self-contained R-KV package ([`../rkv/`](../rkv)) plus a
+small wiring diff ([`../patch/rkv-sglang-0.5.14.patch`](../patch/rkv-sglang-0.5.14.patch)),
+and [`../scripts/apply_rkv.sh`](../scripts/apply_rkv.sh) reproducibly rebuilds a
+patched tree:
 
-`upstream` remote points to official `sgl-project/sglang` for future syncs.
+1. clone upstream SGLang at the **exact pinned commit**
+   `49e384ce9d304648e9959666ecb8ce8cd98d0deb` (release/v0.5.14) into `sglang-src/`;
+2. copy `rkv/*.py` into `sglang-src/python/sglang/srt/mem_cache/rkv/`;
+3. apply the 9-file wiring patch.
+
+The port was developed on a full SGLang fork sitting **directly** on that pinned
+commit with zero unrelated upstream drift, so the tree produced by `apply_rkv.sh`
+is byte-identical to the development tree (see
+[`./REPRODUCE.md`](./REPRODUCE.md) for the equivalence check).
 
 ## 3. The R-KV algorithm (what `algo.py` implements)
 
@@ -133,8 +148,9 @@ File paths are relative to the repo root.
    process, so `Req` length fields are updated in place; the batch `seq_lens`
    tensor is updated from `RKVCompressor.take_pending_length_updates()`.
 5. **O(budget²) similarity** — `cal_similarity` builds a `budget × budget`
-   matrix per layer per trigger. Fine for correctness; a target for phase-2
-   optimization (chunking / cheaper redundancy estimate).
+   matrix per layer per trigger. The per-layer scoring is now **batched across
+   layers** (one pass instead of `num_layers` GEMMs); the O(budget²) matrix
+   itself is still a phase-2 target (chunking / cheaper redundancy estimate).
 
 ## 8. `sparsity/` framework — evaluated, not reused (2026-07)
 
@@ -181,9 +197,9 @@ adaptor), the lifecycle hook names (`on_request_begin/end`,
 ## 9. Status & roadmap
 
 - **[DONE] Phase 1 · step 1** — pure algorithm layer (`algo.py`) + CPU parity
-  tests (`tests/test_rkv_algo.py`). Verified bit-for-bit against an
+  tests (`test/srt/mem_cache/test_rkv_algo.py`). Verified bit-for-bit against an
   inline reference (4 configs incl. GQA and below-budget). Run:
-  `python3 tests/test_rkv_algo.py` (no GPU, no PYTHONPATH needed —
+  `python3 test/srt/mem_cache/test_rkv_algo.py` (no GPU, no PYTHONPATH needed —
   the test loads `algo.py` by file path to bypass the heavy `sglang/__init__.py`).
 - **[DONE] Phase 1 · step 2** — integration layer (route A, §8), wired and
   **verified end-to-end** on Qwen2.5-0.5B (FlashInfer, `batch=1`, `page_size=1`,
@@ -199,7 +215,7 @@ adaptor), the lifecycle hook names (`on_request_begin/end`,
   `observe_decode_layer` in `forward_decode`; end-of-forward `maybe_compact` in
   model_runner; scheduler `_apply_rkv_pre_decode` (on_request_begin + apply the
   physical-length shrink). CPU unit tests:
-  `tests/test_rkv_integration.py`.
+  `test/srt/mem_cache/test_rkv_integration.py`.
 - **[DONE] Phase 1 · step 3** — multi-request batching (`batch >= 1`, method A:
   per-request triggering) + accuracy validation. `observe_decode_layer` loops
   over every request in the decode batch and each request arms / compacts
@@ -214,7 +230,12 @@ adaptor), the lifecycle hook names (`on_request_begin/end`,
   Plain data parallelism (`--dp-size N --tp-size 1`) is also validated — each
   rank runs its own R-KV; throughput scales up to 5.2× on 8× H100 (see
   benchmark/RESULTS_dp.md). TP and dp-attention remain unsupported/untested.
-- **[LATER] Phase 2** — performance: avoid redundant read-back, optimize the
-  O(budget²) similarity, CUDA-graph compatibility, reduce host/device syncs, and
-  **TP ≥ 2 support** (cross-rank all-reduce of per-token scores; see
-  IMPLEMENTATION.md §11.2). Then larger-sample accuracy on MATH-500 / AIME-24.
+- **[DONE] Phase 2 (partial)** — **decode CUDA-graph compatibility** (hybrid
+  eager/graph path) and **batched cross-layer scoring** (one pass instead of
+  `num_layers` GEMMs; +80% decode throughput at `buffer_size=16`, and 8× prefill
+  scoring on a 2174-token prompt) are shipped.
+- **[LATER] Phase 2 (remaining)** — performance: optimize the O(budget²)
+  redundancy matrix, reduce host/device syncs, let the forced-eager window steps
+  replay the graph, and **TP ≥ 2 support** (cross-rank all-reduce of per-token
+  scores; see IMPLEMENTATION.md §11.2). Then larger-sample accuracy on
+  MATH-500 / AIME-24.

--- a/SGLang/docs/DESIGN.md
+++ b/SGLang/docs/DESIGN.md
@@ -229,13 +229,14 @@ adaptor), the lifecycle hook names (`on_request_begin/end`,
   at the two real-finished points; verified per-request state clears to 0.)
   Plain data parallelism (`--dp-size N --tp-size 1`) is also validated — each
   rank runs its own R-KV; throughput scales up to 5.2× on 8× H100 (see
-  benchmark/RESULTS_dp.md). TP and dp-attention remain unsupported/untested.
+  benchmark/RESULTS_dp.md). Tensor parallelism is supported too (cross-rank
+  score all-reduce, §11.2); only dp-attention remains untested.
 - **[DONE] Phase 2 (partial)** — **decode CUDA-graph compatibility** (hybrid
-  eager/graph path) and **batched cross-layer scoring** (one pass instead of
+  eager/graph path), **batched cross-layer scoring** (one pass instead of
   `num_layers` GEMMs; +80% decode throughput at `buffer_size=16`, and 8× prefill
-  scoring on a 2174-token prompt) are shipped.
+  scoring on a 2174-token prompt), and **tensor-parallel support** (cross-rank
+  all-reduce of per-token scores before top-k, so every rank evicts the identical
+  tokens; see IMPLEMENTATION.md §11.2) are shipped.
 - **[LATER] Phase 2 (remaining)** — performance: optimize the O(budget²)
-  redundancy matrix, reduce host/device syncs, let the forced-eager window steps
-  replay the graph, and **TP ≥ 2 support** (cross-rank all-reduce of per-token
-  scores; see IMPLEMENTATION.md §11.2). Then larger-sample accuracy on
-  MATH-500 / AIME-24.
+  redundancy matrix, reduce host/device syncs, and let the forced-eager window
+  steps replay the graph. Then larger-sample accuracy on MATH-500 / AIME-24.

--- a/SGLang/docs/IMPLEMENTATION.md
+++ b/SGLang/docs/IMPLEMENTATION.md
@@ -7,6 +7,12 @@ findings, rejected alternatives, the `sparsity/` framework evaluation), read
 the components, the per-step data flow, the exact wiring points, and the
 decisions baked into them.
 
+> **Scope: decode-time R-KV.** This file documents the *decoding-time* path
+> (`--enable-rkv`). The **prefill-time** mode (`--enable-rkv-prefill`) is a
+> separate integration
+> ([`prefill_integration.py`](../rkv/prefill_integration.py));
+> see [`FINDINGS_AND_ROADMAP.md`](./OPTIMIZATIONS.md).
+
 ## 1. Overview
 
 R-KV is a **decoding-time** KV-cache compressor. While a model generates a long
@@ -56,10 +62,12 @@ past tokens plus the trailing `window` observation tokens.
   the per-request states. Public surface:
   - `on_request_begin(req)` / `on_request_end(req)` — lifecycle.
   - `observe_decode_layer(q, k, v, layer, forward_batch)` — called per layer
-    during decode: caches the query, and (when a compaction is armed) computes
-    and accumulates this layer's per-token score.
+    during decode: caches the query into the observation window. (Scoring is
+    **not** done here; it is batched across all layers in `maybe_compact`.)
   - `maybe_compact(forward_batch)` — called after the full forward pass; for any
-    armed request, assembles the global kept set and physically compacts.
+    armed request, scores all layers in **one batched pass** (with an A/B gate
+    against the per-layer reference), assembles the global kept set, and
+    physically compacts.
   - `override_decode_positions(forward_batch)` — replaces decode positions with
     *logical* positions (see §5).
   - `take_pending_length_updates()` — hands the scheduler the new physical
@@ -80,12 +88,13 @@ FlashInferAttnBackend.init_forward_metadata(fb)   # fb = the REAL decode batch
 
 model.forward → per layer → RadixAttention → FlashInferAttnBackend.forward_decode
   └─ after set_kv_buffer:
-       observe_decode_layer(q, k, v, layer, fb)   # cache query; accumulate score
+       observe_decode_layer(q, k, v, layer, fb)   # cache query into window
                                                    # arm compaction every buffer_size
                                                    # steps once seq_len >= budget
 
 model_runner.forward (after all layers)
-  └─ maybe_compact(fb)                          # for armed reqs: compact
+  └─ maybe_compact(fb)                          # for armed reqs:
+        ├─ score all layers in ONE batched pass (A/B gate vs per-layer ref)
         ├─ assemble kept = top(budget-window) past + trailing window
         └─ _compact_request(...)                # see §6
 ```
@@ -135,15 +144,21 @@ request occupying physical slots `slots = req_to_token[idx, :seq_len]`:
 5. Shrink `req.kv_committed_len / kv_allocated_len = budget`; publish the new
    physical length via `pending_length_updates`.
 
-## 7. Wiring points (5 core files)
+## 7. Wiring points (9 core files)
+
+All changes are additive and applied by [`../patch/rkv-sglang-0.5.14.patch`](../patch/rkv-sglang-0.5.14.patch).
 
 | File | Change |
 | --- | --- |
-| `server_args.py` | `--enable-rkv`; per-field flags `--rkv-budget`, `--rkv-window-size`, `--rkv-kernel-size`, `--rkv-mix-lambda`, `--rkv-retain-ratio`, `--rkv-retain-direction`, `--rkv-buffer-size`, `--rkv-min-seq-len`; `--rkv-config '{...}'` JSON overrides the per-field flags |
-| `model_executor/model_runner.py` | Build `RKVCompressor` in `alloc_memory_pool` (after pools exist); call `maybe_compact` after the decode forward pass |
-| `layers/attention/flashinfer_backend.py` | Backend holds `rkv_compressor`; in `init_forward_metadata` bind it onto the real decode batch + `override_decode_positions`; call `observe_decode_layer` in `forward_decode` after `set_kv_buffer` |
-| `managers/scheduler.py` | Re-bind `rkv_compressor` in `init_memory_pools` (see §8); `_apply_rkv_pre_decode` before `prepare_for_decode` |
-| `managers/scheduler_components/batch_result_processor.py` | Call `on_request_end` at the two real-finished points (beside `hisparse.request_finished`, **not** at retract points) |
+| `server_args.py` | `--enable-rkv` + per-field flags (`--rkv-budget`, `--rkv-window-size`, `--rkv-kernel-size`, `--rkv-mix-lambda`, `--rkv-retain-ratio`, `--rkv-retain-direction`, `--rkv-buffer-size`, `--rkv-min-seq-len`), `--rkv-config` JSON override, `--rkv-max-active-requests`, `--rkv-fused-validation`; prefill mode `--enable-rkv-prefill` + `--rkv-prefill-config`. `_handle_rkv_validation` / `_handle_rkv_prefill_validation` reject unsafe combos at startup |
+| `model_executor/model_runner.py` | Build `RKVCompressor` (and the prefill compressor) in `alloc_memory_pool` after the pools exist; call `maybe_compact` after the decode forward pass |
+| `model_executor/model_runner_kv_cache_mixin.py` | Reserve the R-KV auxiliary GPU memory (the `rolling_q` observation-query buffer **and** the transient compaction workspace) inside KV-pool sizing so admission accounting is correct; apply the `--rkv-max-active-requests` cap on `max_running_requests` |
+| `model_executor/forward_batch_info.py` | Restore **logical** rotary positions (`override_decode_positions`) at `ForwardBatch` construction so both eager and captured-CUDA-graph decode read the correct positions |
+| `layers/attention/flashinfer_backend.py` | Backend holds `rkv_compressor` / `rkv_prefill_compressor`; bind onto the real decode batch in `init_forward_metadata`; call `observe_decode_layer` (decode) / `observe_prefill_layer` (prefill) after `set_kv_buffer` |
+| `managers/scheduler.py` | Re-bind the compressor in `init_memory_pools` (see §8); `_apply_rkv_pre_decode` before `prepare_for_decode`; `commit_compactions` after the decode forward (two-phase compaction, §6) |
+| `managers/scheduler_components/batch_result_processor.py` | Call `on_request_end` at the two real-finished points (beside `hisparse.request_finished`); commit any queued compaction frees before the finished-request release loop |
+| `managers/schedule_batch.py` | `on_request_retract` hooks so a retracted request drops its per-request compressor state while `req_pool_idx` is still valid (avoids stale bookkeeping / KV leak on the next prefill) |
+| `managers/schedule_policy.py` | **Compression-aware admission**: `PrefillAdder` reserves a request's *constant* compressed KV ceiling (`min(prompt, budget) + output`) instead of `prompt + output`, so many more requests are admitted concurrently |
 
 ## 8. Bugs fixed during bring-up
 
@@ -171,9 +186,10 @@ request occupying physical slots `slots = req_to_token[idx, :seq_len]`:
    subtract 1 (see §5).
 5. **No startup validation of R-KV-incompatible flags (owner review, 2026-07-02).**
    `--enable-rkv` silently corrupted the KV pool when combined with the radix
-   cache, a captured decode CUDA graph, overlap scheduling, `page_size > 1`, or
-   `tp > 1`. Fix: `ServerArgs._handle_rkv_validation` now rejects those combos at
-   startup with an explicit error.
+   cache, overlap scheduling, `page_size > 1`, or `tp > 1`. Fix:
+   `ServerArgs._handle_rkv_validation` now rejects those combos at startup with an
+   explicit error. (Decode CUDA graph was **later made compatible** via the
+   hybrid eager/graph path and is no longer rejected.)
 
 ## 9. Environment (dev-v0.5.14 needs a newer stack than v0.5.3-era wheels)
 
@@ -185,16 +201,18 @@ request occupying physical slots `slots = req_to_token[idx, :seq_len]`:
 
 ## 10. Running & validation
 
-Launch (phase-1 flags are required — R-KV runs only on the **eager decode**
-path, so decode CUDA graph must be off; `page_size=1` for clean slot free;
-overlap off for simple timing):
+Launch (required flags — radix cache off so R-KV can free slots, overlap off,
+`page_size=1` for clean slot free). **Decode CUDA graph is supported and left on**
+via the hybrid eager/graph path (the `window_size` steps ending at each
+compaction, plus the compaction step, run eager; every other decode step replays
+the captured graph). Pass `--disable-decode-cuda-graph` only if you want the
+fully-eager path:
 
 ```bash
-PYTHONPATH=sglang-src/python HF_HUB_DISABLE_XET=1 python3 -m sglang.launch_server \
+PYTHONPATH=$PWD/python HF_HUB_DISABLE_XET=1 python3 -m sglang.launch_server \
   --model-path /data/model/Qwen2.5-0.5B-Instruct \
   --attention-backend flashinfer \
-  --disable-decode-cuda-graph --disable-prefill-cuda-graph \
-  --disable-overlap-schedule --page-size 1 \
+  --disable-radix-cache --disable-overlap-schedule --page-size 1 \
   --enable-rkv --rkv-config '{"budget":64,"window_size":8,"buffer_size":16}' \
   --mem-fraction-static 0.6 --host 127.0.0.1 --port 30000
 ```
@@ -208,7 +226,7 @@ CPU unit tests (no GPU, no installed `sglang` needed — modules are loaded by
 path):
 
 ```bash
-python3 tests/test_rkv_integration.py
+python3 test/srt/mem_cache/test_rkv_integration.py
 ```
 
 9 cases: kept-set assembly, slot relocation, overlap safety, physical-length
@@ -304,18 +322,18 @@ hooks.
 | DP attention (`--enable-dp-attention`) | ❌ untested | implies tp>1 (blocked); padded forward_batch layout unverified |
 
 > **Enforced at startup:** `ServerArgs._handle_rkv_validation` rejects
-> `--enable-rkv` together with `--tp > 1` (and radix cache / decode CUDA graph /
-> overlap schedule / `page_size > 1`), so the silently-incorrect TP path cannot
+> `--enable-rkv` together with `--tp > 1` (and radix cache / overlap schedule /
+> `page_size > 1`), so the silently-incorrect TP path cannot
 > be launched by accident. Plain DP (`--dp-size N --tp-size 1`) is allowed and
 > validated (§11.3); implementing the §11.2 cross-rank all-reduce is what would
 > lift the TP block.
 
 ## 12. Other limitations / next
 
-- **O(budget²) similarity** in `cal_similarity` — a phase-2 perf target
-  (chunking / a cheaper redundancy estimate).
-- **No CUDA-graph decode** yet (dynamic eviction can't live in a captured
-  graph). Phase-2 would need a graph-compatible compaction scheme.
+- **O(budget²) similarity** in `cal_similarity` — the per-layer scoring GEMMs are
+  now **batched across layers** (one pass instead of `num_layers`); the per-token
+  O(budget²) redundancy matrix itself is still a phase-2 target (chunking / a
+  cheaper redundancy estimate).
 - **`on_request_end`** is wired at finish, but state is otherwise only cleared
   lazily on `req_pool_idx` reuse — fine for phase 1.
 - Larger-sample accuracy (MATH-500 / AIME-24) and a long-sequence throughput

--- a/SGLang/docs/IMPLEMENTATION.md
+++ b/SGLang/docs/IMPLEMENTATION.md
@@ -235,10 +235,10 @@ bookkeeping, logical-position decoupling, request lifecycle
 
 ## 11. Parallelism & batching support
 
-**Current status: single-GPU, `batch >= 1`** — validated at
-`tp_size=1, dp_size=1` for both `batch=1` and `batch > 1`. Tensor parallel (TP)
-and data parallel (DP) are **not** supported. The integration layer contains
-**no distributed code** (no `tp_group`, no `all_reduce`, no `torch.distributed`).
+**Current status: `batch >= 1`, `tp >= 1`, plain `dp >= 1`.** Validated for
+`batch=1` and `batch > 1`; **tensor parallel (TP) is supported** via a cross-rank
+score all-reduce (§11.2); **plain data parallel (DP) is supported** (§11.3). The
+only unsupported multi-GPU mode is **DP attention** (`--enable-dp-attention`).
 
 ### 11.1 `batch > 1` — supported (method A: per-request triggering)
 
@@ -256,43 +256,56 @@ accumulators, query ring buffers, and compaction are all keyed by
 > method A while adding wasted checks on short requests and ragged-slot batching
 > overhead — no speedup.
 
-### 11.2 Tensor parallel (TP ≥ 2) — NOT supported, silently incorrect ⚠️
-
-This is the dangerous case: it will not crash, it will **corrupt the KV cache**.
+### 11.2 Tensor parallel (TP ≥ 2) — supported (cross-rank score all-reduce)
 
 Under TP, each rank holds only a **subset of the KV heads**. R-KV's importance /
-redundancy score is reduced with a **mean over heads** — but each rank can only
-see *its own* heads. Therefore:
+redundancy score is reduced with a **mean over heads**, so each rank's *local*
+score sees only its own heads. Left uncoordinated this is the dangerous case: it
+does not crash, it **corrupts the KV cache**. Each rank would select a
+**different** `kept` set, yet KV-slot allocation and `req_to_token` are
+synchronized and identical across ranks — so `_compact_request` would rewrite
+`req_to_token` differently and `free()` different physical slots per rank, and
+the physical KV layout would **silently diverge** (wrong attention outputs,
+eventual pool corruption; nothing detects it because each rank is internally
+self-consistent).
 
-1. each rank computes a **different** per-token score → selects a **different**
-   `kept` set;
-2. yet KV-slot allocation and `req_to_token` are **synchronized and identical**
-   across ranks (every rank gets the same `out_cache_loc` each step, and the
-   scheduler drives one logical sequence);
-3. so `_compact_request` rewrites `req_to_token` **differently** and calls
-   `free()` on **different physical slots** on each rank → the physical KV
-   layout **diverges between ranks**.
+**Fix (implemented).** The per-token score is **all-reduced (SUM) across the
+attention-TP group before `_assemble_kept`**, so every rank tops-k the *same*
+global score and evicts the *identical* tokens, keeping the replicated
+`req_to_token` consistent. This is correct because the score is a cross-head
+**mean** and every softmax/pool inside it is **per-head** (over the sequence
+axis) → the cross-head reduction is **linear**. Head sharding is uniform
+(`num_kv_heads % tp == 0` for distinct heads, or `tp % num_kv_heads == 0` with
+uniform replication), so the all-reduced SUM equals the true global cross-head
+mean scaled by a positive constant; `topk` is invariant to positive scaling, so
+the kept set is identical on every rank.
 
-Once the layout diverges, FlashInfer reads the wrong slots on some ranks and the
-allocator's slot accounting no longer matches the (shared) `req_to_token` — i.e.
-wrong attention outputs and, eventually, pool corruption. **Nothing detects
-this**, because each rank is internally self-consistent; only the *cross-rank*
-agreement is broken.
+Implementation:
 
-**To support TP**, the per-token score must be **all-reduced across the
-attention-TP group** (summing each rank's head contributions) into one global
-score *before* `kept` is assembled, so every rank evicts the **exact same**
-tokens and keeps `req_to_token` identical. Concretely the compressor would need:
+- the compressor takes an `attn_tp_group` handle
+  (`model_runner.attention_tp_group`, i.e. `get_attention_tp_group()`), stored as
+  `self.attn_tp_group` / `self.attn_tp_size`; `None` / `world_size == 1` makes
+  the path a no-op, so the single-GPU code is unchanged;
+- `_reduce_score_across_tp(score)` does `attn_tp_group.all_reduce(score.float())`
+  (fp32 so ties break identically on every rank) on each score right before
+  `_assemble_kept`, in both the decode (`maybe_compact`) and prefill paths;
+- armed requests are iterated in **sorted `req_pool_idx` order** so every rank
+  issues its collectives in the same order (a mismatched order would mis-pair
+  tensors or hang);
+- `_check_kept_consistent_across_tp(kept)` all-reduces the kept indices and
+  raises `RuntimeError` if any rank disagrees — self-validating on the first few
+  compactions, or on **every** compaction when `SGLANG_RKV_TP_CHECK=1`.
 
-- a handle to the attention-TP process group (e.g. `model_runner.tp_group` /
-  `attention_tp_group`);
-- an `all_reduce(SUM)` of the accumulated per-token score in `maybe_compact`,
-  right before `_assemble_kept`;
-- (ideally) an assertion that every rank derived the identical `kept` indices.
+**Validated (8x H100)** with `SGLANG_RKV_TP_CHECK=1` forcing the consistency
+check on every compaction, across all three head-sharding regimes:
 
-None of this exists today, so **`--tp 2` or higher will silently produce wrong
-results.** If TP is attempted before this is implemented, it should be hard-
-blocked in `server_args` (reject `enable_rkv && tp_size > 1`).
+| tp | model (Q/KV heads) | local KV heads | phase | result |
+| --- | --- | --- | --- | --- |
+| 2 | Qwen2.5-Math-7B (28/4) | 2/rank (distinct) | decode | both ranks compact the same `req_pool_idx` at the same step, identical freed count; assertion never fired |
+| 4 | Qwen2.5-Math-7B (28/4) | 1/rank (distinct) | decode | all 4 ranks 6 compactions each in lockstep; outputs byte-identical to tp=2 |
+| 8 | Qwen3-30B-A3B (32/4) | 4 KV replicated x2 | prefill | all 8 ranks 4 compactions each in lockstep (`1163 -> 512`, freed 651); assertion never fired |
+
+**DP attention** (`--enable-dp-attention`) is still unsupported (§11.3).
 
 ### 11.3 Data parallel (DP ≥ 2)
 
@@ -304,12 +317,12 @@ Qwen2.5-Math-7B (8× H100): every rank compresses independently, accuracy matche
 single-GPU, no leaks/crashes, and throughput scales up to **5.2× on 8 GPUs**. See
 [`../benchmark/RESULTS_dp.md`](../benchmark/RESULTS_dp.md).
 
-**DP attention (`--enable-dp-attention`) — still untested.** This mode makes
-attention data-parallel while MoE/FFN stay tensor-parallel (it implies `tp>1`,
-which the startup guard currently rejects). Its padded/scattered `forward_batch`
-layout (per-rank `num_real_reqs`, all-gather of attention inputs) has **not been
+**DP attention (`--enable-dp-attention`) — still unsupported.** This mode makes
+attention data-parallel while MoE/FFN stay tensor-parallel. While plain TP is now
+supported (§11.2), DP attention's padded/scattered `forward_batch` layout
+(per-rank `num_real_reqs`, all-gather of attention inputs) has **not been
 tested** against R-KV's `observe` / `override_decode_positions` / `maybe_compact`
-hooks.
+hooks, so it is left unsupported.
 
 ### Support matrix
 
@@ -317,16 +330,16 @@ hooks.
 | --- | --- | --- |
 | `batch=1, tp=1, dp=1` | ✅ validated | — |
 | `batch > 1` (tp=1, dp=1) | ✅ supported | per-request triggering (method A) |
-| **TP ≥ 2** | ❌ **silently incorrect** | **missing cross-rank all-reduce of scores** (fundamental) |
+| **TP ≥ 2** | ✅ supported | cross-rank score all-reduce before top-k (§11.2) |
 | DP ≥ 2 (plain, `tp=1`) | ✅ validated | per-rank independent R-KV (see benchmark/RESULTS_dp.md) |
-| DP attention (`--enable-dp-attention`) | ❌ untested | implies tp>1 (blocked); padded forward_batch layout unverified |
+| DP attention (`--enable-dp-attention`) | ❌ unsupported | padded forward_batch layout unverified against the hooks |
 
-> **Enforced at startup:** `ServerArgs._handle_rkv_validation` rejects
-> `--enable-rkv` together with `--tp > 1` (and radix cache / overlap schedule /
-> `page_size > 1`), so the silently-incorrect TP path cannot
-> be launched by accident. Plain DP (`--dp-size N --tp-size 1`) is allowed and
-> validated (§11.3); implementing the §11.2 cross-rank all-reduce is what would
-> lift the TP block.
+> **Enforced at startup:** `ServerArgs._handle_rkv_validation` requires
+> `--disable-radix-cache` / `--disable-overlap-schedule` / `--page-size 1`, and a
+> late, post-resolution gate in `ModelRunner` rejects runtimes the hooks are not
+> wired for (non-FlashInfer backend, MLA, hybrid-SWA, speculative decoding).
+> **Plain TP and plain DP are allowed and validated** (§11.2 / §11.3);
+> DP attention remains unsupported.
 
 ## 12. Other limitations / next
 

--- a/SGLang/docs/OPTIMIZATIONS.md
+++ b/SGLang/docs/OPTIMIZATIONS.md
@@ -158,9 +158,11 @@ false-fired, no OOM, correct answers.
 - **Prefill CUDA graph must be OFF** for `--enable-rkv-prefill` (prompt-phase
   scoring/compaction are dynamic shapes); it gives ~0% benefit on long prompts
   anyway (compute-bound). Decode CUDA graph is supported for both modes.
-- **TP ≥ 2 is not supported** (silently incorrect without a cross-rank score
-  all-reduce; hard-blocked at startup). Plain DP (`--dp-size N --tp-size 1`) is
-  validated. See [`IMPLEMENTATION.md`](./IMPLEMENTATION.md) §11.
+- **TP ≥ 2 is supported** (the per-token eviction score is all-reduced across the
+  attention-TP group before top-k, so every rank evicts the identical tokens);
+  plain DP (`--dp-size N --tp-size 1`) is also validated. Only DP attention
+  (`--enable-dp-attention`) is unsupported. See
+  [`IMPLEMENTATION.md`](./IMPLEMENTATION.md) §11.
 - Use **`--ignore-eos`** for clean equal-work throughput A/B (compression changes
   output length, which otherwise confounds `gen_throughput`).
 

--- a/SGLang/docs/OPTIMIZATIONS.md
+++ b/SGLang/docs/OPTIMIZATIONS.md
@@ -1,0 +1,190 @@
+# R-KV on SGLang — Optimizations & Production Hardening
+
+This document is the "what makes the port fast and safe" layer. Read
+[`DESIGN.md`](./DESIGN.md) (architecture) and [`IMPLEMENTATION.md`](./IMPLEMENTATION.md)
+(code map) first; this file collects the **performance optimizations** and the
+**production-hardening** work layered on top of the correct-but-naive port, with
+the measured effect of each.
+
+There are two R-KV compressors, which share the same paged-pool eviction
+machinery but differ in *when* they compress:
+
+| Compressor | File | Compaction timing | Scoring cost |
+| --- | --- | --- | --- |
+| **decode R-KV** (`--enable-rkv`) | [`../rkv/integration.py`](../rkv/integration.py) | every `buffer_size` decode steps | importance + redundancy |
+| **R-KV-prefill** (`--enable-rkv-prefill`) | [`../rkv/prefill_integration.py`](../rkv/prefill_integration.py) | end of prefill (`oneshot`) or mid-prefill (`buffered`) | importance + O(n²) redundancy |
+
+---
+
+## 1. Performance optimizations
+
+### 1.1 In-graph observation + hybrid CUDA-graph decode
+Decode R-KV needs the last `window_size` decode queries per request for
+importance scoring. Collecting them used to force **every** decode step eager.
+Now the observation-query collection runs **inside the captured decode CUDA
+graph** (a fixed-address rolling buffer written in-graph, keyed by a per-request
+GPU step counter), so only the `window_size` steps ending at a compaction — plus
+the compaction step itself — run eager; every other decode step **replays the
+captured graph**. Logical rotary positions are restored at `ForwardBatch`
+construction so both the eager and the replayed path read correct positions.
+
+*Effect:* decode CUDA graph is now **supported** (the old port was eager-only).
+End-to-end on Qwen2.5-Math-7B, budget 512, 8 concurrent: **~424 tok/s eager →
+~580 tok/s with the decode graph on (+37%)**, same accuracy within n=20 noise
+(see [`REPRODUCE.md`](./REPRODUCE.md)).
+
+### 1.2 Batched cross-layer scoring
+Scoring is per-layer (each layer contributes its own `q·kᵀ` importance and
+key-similarity redundancy). The naive port ran one GEMM **per layer**
+(`num_layers` launches). Scoring is now **batched across layers** in a single
+pass.
+
+*Effect:* removes the layer-loop launch overhead — **8× on a short (2174-token)
+prompt** (94 ms → 12 ms, launch-bound) and **+80% decode throughput at
+`buffer_size=16`**. Note: on long (8–23 K-token) prompts the per-layer O(n²)
+redundancy *compute* dominates, so batching is compute-neutral there — that
+remaining O(n²) is the top roadmap item (§4).
+
+### 1.3 Fused Triton redundancy kernel (+ startup validation gate)
+The O(n²) key cosine-similarity redundancy term has a **fused Triton kernel**
+([`../rkv/redundancy_fused.py`](../rkv/redundancy_fused.py)) that computes the
+row-blocked similarity → mean → softmax without materializing the full `n×n`
+matrix. It is validated against the tiled/reference path (bit-parity gate) and
+falls back **permanently** to the reference on any per-call compile/exec failure
+(never crashes the server).
+
+`--rkv-fused-validation` controls *when* the gate runs:
+- `startup` (default) — validate once at load on a synthetic tensor sized to the
+  real model's kv-heads/head-dim/dtype, so **no real request pays the gate**;
+- `first-request` — validate lazily on the first real compaction (the old
+  behavior; an unlucky long first prompt paid the cost);
+- `off` — never use the fused kernel (always the reference path).
+
+*Determinism:* measured run-to-run jitter on H100 = **0.0 for bf16/fp16, ~1e-10
+for fp32**, and the top-k kept set never flips.
+
+### 1.4 Host-sync reduction on the hot path
+Two GPU→CPU syncs were removed with no behavior change:
+- `override_decode_positions` replaced a per-request `.item()` (one device sync
+  **per request, every decode step**) with a single `.tolist()` + one batched
+  scatter;
+- `observe_prefill_layer` computed its host-side batch metadata **once per
+  layer**; it now computes it once per forward (at layer 0) and reuses it,
+  saving `num_layers − 1` syncs per prefill.
+
+### 1.5 Compression-aware admission — the throughput unlock
+A decode R-KV request's steady-state KV footprint is `min(prompt, budget) +
+output`, **not** `prompt + output`. The scheduler's `PrefillAdder`
+([`schedule_policy.py`](../patch/rkv-sglang-0.5.14.patch)) reserves that smaller,
+*constant* compressed ceiling at admission, so many more requests run
+concurrently under a fixed KV pool.
+
+*Effect (memory-bound regime):* peak concurrent running-requests **10 → 65
+(6.5×)** for R-KV-prefill; the concurrency edge **grows with prompt length**
+because the Full-KV footprint scales with the prompt while R-KV's stays constant
+(equal-work `--ignore-eos` A/B: even at ~5 K prompt, **1.48× at ~20 K**).
+
+> R-KV wins on throughput **only when memory-bound**. With a large (non-pressured)
+> KV pool, Full KV wins because there is no memory pressure to exploit and R-KV
+> still pays its scoring cost. Quality is lossless at budget 4096 on a 30B
+> summarization judge (Full 75/136 == R-KV oneshot 75/136).
+
+---
+
+## 2. Production hardening
+
+The correct-but-naive port had several safety and accounting gaps that only bite
+at scale. These were closed and covered with tests.
+
+### 2.1 Memory accounting — reserve every R-KV allocation
+The KV-slot admission accounting only tracked pool tokens, not the R-KV
+transients. Both are now reserved in KV-pool sizing
+([`model_runner_kv_cache_mixin.py`](../patch/rkv-sglang-0.5.14.patch)):
+- the decode **rolling observation-query buffer** (`rolling_q`, one row per
+  request-pool slot — ~6.1 GiB on a 7B at `max_running_requests=4096`);
+- the transient **compaction workspace** (the batched similarity matrix +
+  gathered keys + per-layer relocation clones, capped by the score-chunk bound
+  + 25% ≈ 0.6 GiB).
+
+`--rkv-max-active-requests` caps `max_running_requests` when R-KV is on, which
+cascades to `req_to_token`, `rolling_q`, and the reservation — e.g. cap 128
+shrinks `rolling_q` **6.13 → 0.19 GiB**, returning ~5.9 GiB to the KV pool.
+
+### 2.2 Two-phase compaction (decouples forward compute from allocator state)
+Compaction used to call `kv_allocator.free()` from **inside** the forward (on the
+forward stream), which is the root of the overlap free-list race. It is now split:
+- **prepare** (in the decode forward): relocate surviving K/V to the front
+  `budget` slots and queue a commit record — **no allocator mutation**;
+- **commit** (in the scheduler, after the forward completes, at a stream-synced
+  point, *before* the finished-request release loop): free the evicted tail and
+  finalize per-request length bookkeeping.
+
+This removes the cross-layer coupling and makes a compact-and-finish-in-the-same-
+step request free its tail exactly once (no double-free). (Overlap is still
+disabled for R-KV, but the *blocker* is gone — see §3.)
+
+### 2.3 Per-request rolling-query cursor
+The in-graph observation buffer used a single **global** circular cursor advanced
+every decode step. If any managed request skipped a step (preemption / future
+overlap), the global cursor advanced anyway, wedging a phantom unwritten slot
+between a request's real queries and corrupting its importance window. Replaced
+with a **per-request** GPU step counter (`step_count_of_req`, keyed by
+`req_pool_idx`) so each request's window advances only on steps it participates
+in — correct regardless of batch membership.
+
+### 2.4 Un-bypassable invariant guards
+Safety-critical checks were converted from `assert` (stripped by `python -O`) to
+explicit `RuntimeError` / `ValueError`, and the compaction kept-set and the
+**whole** `req_to_token` slot table are validated for 1-to-1 uniqueness **before**
+any KV buffer is mutated (a duplicate slot could put one slot in both the freed
+tail and the kept head → use-after-free). Added a stale-plan identity guard
+(request slot released/reused between prepare and commit) and fail-fast on any
+lifecycle desync. In-place relocation means any exception is unrecoverable and
+must terminate the worker rather than be silently swallowed.
+
+*GPU-validated:* 40-way near-saturation stress, 202 compactions — guards never
+false-fired, no OOM, correct answers.
+
+---
+
+## 3. Known constraints & gotchas
+
+- **Overlap schedule must be OFF** for both R-KV modes. Even with two-phase
+  compaction the mode stays gated off (`--disable-overlap-schedule` required):
+  re-enabling it needs the compaction free deferred to the scheduler's synced
+  default-stream point *and* expensive large-scale race re-validation. The race
+  only reproduces at real scale (30B, dp8, async); `CUDA_LAUNCH_BLOCKING=1` and
+  small models **hide** it.
+- **Prefill CUDA graph must be OFF** for `--enable-rkv-prefill` (prompt-phase
+  scoring/compaction are dynamic shapes); it gives ~0% benefit on long prompts
+  anyway (compute-bound). Decode CUDA graph is supported for both modes.
+- **TP ≥ 2 is not supported** (silently incorrect without a cross-rank score
+  all-reduce; hard-blocked at startup). Plain DP (`--dp-size N --tp-size 1`) is
+  validated. See [`IMPLEMENTATION.md`](./IMPLEMENTATION.md) §11.
+- Use **`--ignore-eos`** for clean equal-work throughput A/B (compression changes
+  output length, which otherwise confounds `gen_throughput`).
+
+---
+
+## 4. Optimization roadmap (ROI-ordered)
+
+1. **Kill R-KV-prefill's O(n²) prefill scoring** (highest value — it is why
+   R-KV-prefill only ties Full KV at 5 K prompts instead of winning):
+   - *cross-layer subsampling* — score K of N layers (compute ÷ N/K); cheapest,
+     biggest win — validate keep-set Jaccard + judge accuracy A/B first;
+   - *redundancy-term approximation* — local/blocked similarity or clustering
+     instead of full pairwise `k_norm @ k_normᵀ`, bounding compute to O(n·w);
+   - *fp8 / lower-precision scoring* — scores only need to rank tokens;
+   - *fused scoring+relocate sgl-kernel* — hardest, highest ceiling.
+2. **True mid-prefill physical KV release** — compress *during* prefill so input
+   length can exceed the KV pool (buffered mode does a logical compaction today
+   but not physical release; requires decoupling chunked-prefill's processed-len
+   invariant).
+3. **Async-safe overlap** — defer the compaction `free()` to the scheduler's
+   synced point, then re-enable overlap (low priority: ~2–5% at scale on the
+   prefill-bound workload).
+4. **Decode R-KV throughput** — adaptive compaction frequency, cross-layer score
+   *subsampling*, relocate on a separate CUDA stream, and letting the forced-
+   eager window steps replay the graph.
+5. **Quality robustness** — multi-seed / larger-sample judging (n=136 single-pass
+   is ~±2 rows of noise, which flips A-vs-B at some budgets).

--- a/SGLang/docs/REPRODUCE.md
+++ b/SGLang/docs/REPRODUCE.md
@@ -1,0 +1,182 @@
+# Reproduction & Usage Guide
+
+Exact, copy-pasteable steps to reproduce the R-KV port on SGLang v0.5.14,
+validated on **8× NVIDIA H100 (80 GB), CUDA 12.9, Python 3.12**. Every command
+and every number below was run on that box.
+
+- Design → [`DESIGN.md`](./DESIGN.md)
+- Code map → [`IMPLEMENTATION.md`](./IMPLEMENTATION.md)
+- Optimizations & hardening → [`OPTIMIZATIONS.md`](./OPTIMIZATIONS.md)
+
+---
+
+## 0. Pinned stack
+
+| Component | Pin |
+| --- | --- |
+| Hardware | NVIDIA H100 80 GB |
+| CUDA | 12.9 |
+| Python | 3.12 |
+| **SGLang** | upstream commit `49e384ce9d304648e9959666ecb8ce8cd98d0deb` (release/v0.5.14) |
+| torch | `2.11.0+cu129` |
+| sglang-kernel | `0.4.4+cu129` |
+| flashinfer | `flashinfer-python==0.6.12`, `flashinfer-cubin==0.6.12` |
+| transformers | `5.8.1` |
+| triton | `3.6.0` |
+
+The exact versions are in [`../requirements-rkv.txt`](../requirements-rkv.txt).
+
+---
+
+## 1. Build the patched tree
+
+```bash
+cd SGLang                       # this directory
+bash scripts/apply_rkv.sh       # clone pinned SGLang -> sglang-src/, drop in rkv/, apply patch
+```
+
+This clones upstream SGLang at the pinned commit into `sglang-src/` (git-ignored),
+copies the 6-file `rkv/` package into
+`sglang-src/python/sglang/srt/mem_cache/rkv/`, and applies the **9-file** wiring
+patch. It fails loudly (`git apply --check`) if the patch would not apply cleanly.
+
+> To build from a local SGLang clone instead of GitHub, set `SGLANG_REPO`:
+> `SGLANG_REPO=/path/to/local/sglang bash scripts/apply_rkv.sh --force`.
+
+Install the dependency stack (skip if your env already matches §0):
+
+```bash
+pip install -e "sglang-src/python" --extra-index-url https://docs.sglang.ai/whl/cu129/
+pip install -r requirements-rkv.txt --extra-index-url https://docs.sglang.ai/whl/cu129/
+```
+
+---
+
+## 2. Unit tests (GPU-free algorithm + integration; fused test needs a GPU)
+
+All modules load by file path, so no installed `sglang` is required.
+
+```bash
+python3 tests/test_rkv_algo.py                 #  7 tests — algorithm parity vs reference
+python3 tests/test_rkv_integration.py          # 24 tests — compaction / lifecycle / memory / batch>=2
+python3 tests/test_rkv_prefill.py              #  9 tests — prefill algorithm (tiled/oneshot/buffered)
+python3 tests/test_rkv_prefill_integration.py  # 11 tests — prefill compaction & admission
+python3 tests/test_rkv_redundancy_fused.py     # 11 tests — fused Triton redundancy kernel (needs CUDA+Triton)
+python3 tests/test_cross_repo_parity.py        # bit-level parity vs this repo's rkv/ reference
+```
+
+**Validated result:** `62/62` unit tests pass; `test_cross_repo_parity.py` prints
+`ALL PARITY CHECKS PASSED (bit-for-bit)` across MHA / GQA / batch>1 / fp32 / bf16.
+
+---
+
+## 3. Equivalence check (optional but recommended)
+
+The tree produced by `apply_rkv.sh` is byte-identical to the development tree.
+To confirm the patch reconstructs exactly the intended source:
+
+```bash
+# after apply_rkv.sh has produced sglang-src/
+diff -rq --no-dereference \
+  <(cd sglang-src/python/sglang/srt && find . -name '*.py' | sort) \
+  <(...your reference tree...)   # empty diff == identical
+```
+
+During porting this was verified against the development fork: with
+`--no-dereference` the `python/sglang/srt` diff was **empty**, and all 15 changed
+files (6 `rkv/` + 9 wiring) matched by `sha256`.
+
+---
+
+## 4. Serve + evaluate (Qwen2.5-Math-7B, single H100)
+
+```bash
+bash benchmark/prepare_data.sh                                   # bundled GSM8K few-shot data
+MODEL=/data/model/Qwen2.5-Math-7B-Instruct bash benchmark/launch_server.sh rkv 512
+# in another shell (same env):
+python3 benchmark/eval.py --n 20 --concurrency 8 --label rkv_b512
+```
+
+`launch_server.sh` sets `PYTHONPATH=sglang-src/python` and the required flags.
+
+### Validated numbers
+
+**Decode R-KV, budget 512, `n=20`, concurrency 8** — three back-to-back runs
+(eager decode path):
+
+| Run | Accuracy | avg_tokens | Throughput | KV compactions |
+| --- | --- | --- | --- | --- |
+| 1 | 19/20 = 0.950 | 195 | 423.6 tok/s | 232 |
+| 2 | 19/20 = 0.950 | 195 | 427.1 tok/s | 232 |
+| 3 | 19/20 = 0.950 | 195 | 424.4 tok/s | 232 |
+
+Stable at **95 % (== eager baseline)** with **~232 physical KV compactions per
+run, zero crashes / leaks / double-frees**.
+
+**Decode R-KV + decode CUDA graph ON** (the hardening headline — the old port was
+eager-only). Launch without `--disable-decode-cuda-graph`:
+
+```bash
+export PYTHONPATH="$PWD/sglang-src/python"
+python3 -m sglang.launch_server \
+  --model-path /data/model/Qwen2.5-Math-7B-Instruct \
+  --attention-backend flashinfer \
+  --disable-radix-cache --disable-overlap-schedule --disable-prefill-cuda-graph \
+  --page-size 1 --mem-fraction-static 0.6 --host 127.0.0.1 --port 30011 \
+  --enable-rkv --rkv-config '{"budget":512,"window_size":8,"buffer_size":16}'
+python3 benchmark/eval.py --n 20 --concurrency 8 --port 30011 --label rkv_graphON
+```
+
+Result: decode graph captures all 36 batch sizes and the decode loop runs under
+it (`cuda graph: True`); **18/20 = 0.900** (a single-item flip vs eager, within
+n=20 noise), **579.6 tok/s (+37 % over eager)**, 228 compactions, **zero errors**.
+The server log shows `R-KV decode fused-redundancy gate: OK -> fused adopted`
+(the `--rkv-fused-validation startup` gate).
+
+---
+
+## 5. Configuration reference
+
+Enable decode R-KV with `--enable-rkv`; every hyper-parameter has a flat flag and
+a `--rkv-config` JSON override.
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--rkv-budget` | `1024` | KV entries kept per request after compression |
+| `--rkv-window-size` | `8` | trailing observation window, always retained |
+| `--rkv-kernel-size` | `7` | pooling kernel for importance smoothing |
+| `--rkv-mix-lambda` | `0.1` | importance vs redundancy mix (1 = importance only) |
+| `--rkv-retain-ratio` | `0.1` | fraction of recent similar neighbours exempted |
+| `--rkv-retain-direction` | `last` | `last` / `first` / `last_percent` / `first_percent` |
+| `--rkv-buffer-size` | `128` | compress every N newly generated tokens per request |
+| `--rkv-min-seq-len` | `budget` | min KV length before compression is considered |
+| `--rkv-config` | — | JSON overriding any of the above, e.g. `'{"budget":512,"buffer_size":16}'` |
+| `--rkv-max-active-requests` | — | cap concurrent R-KV requests → shrinks the `rolling_q` buffer (trades concurrency for memory) |
+| `--rkv-fused-validation` | `startup` | when to validate the fused kernel: `startup` / `first-request` / `off` |
+
+Prompt-phase compression uses `--enable-rkv-prefill` (+ `--rkv-prefill-config`
+JSON; `mode` is `oneshot` or `buffered`). It additionally requires
+`--disable-prefill-cuda-graph`.
+
+### Required flags
+
+Decode R-KV (`--enable-rkv`): `--disable-radix-cache --disable-overlap-schedule
+--page-size 1`, `tp == 1`. **Decode CUDA graph is supported** (enabled by default;
+pass `--disable-decode-cuda-graph` only for a fully-eager, bit-reproducible run).
+Prefill R-KV (`--enable-rkv-prefill`) additionally needs
+`--disable-prefill-cuda-graph` and cannot combine with `--enable-rkv`. These are
+enforced at startup by `_handle_rkv_validation` / `_handle_rkv_prefill_validation`.
+
+---
+
+## 6. Gotchas
+
+- Launch servers detached (`setsid ... </dev/null & disown`) so they survive an
+  agent's terminal cleanup.
+- Temperature-0 eval is deterministic, so accuracy repeats exactly across runs of
+  the same config; run multiple times to confirm **stability under compaction**
+  (compaction count / no crashes), not to average accuracy.
+- The one-item accuracy delta between eager and CUDA-graph decode is expected
+  kernel-selection noise at `n=20`, not a correctness bug — both are ≈95 %.
+- `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE` defaults on: any idle KV leak
+  crashes the scheduler, so a clean run is itself a no-leak proof.

--- a/SGLang/docs/REPRODUCE.md
+++ b/SGLang/docs/REPRODUCE.md
@@ -161,11 +161,13 @@ JSON; `mode` is `oneshot` or `buffered`). It additionally requires
 ### Required flags
 
 Decode R-KV (`--enable-rkv`): `--disable-radix-cache --disable-overlap-schedule
---page-size 1`, `tp == 1`. **Decode CUDA graph is supported** (enabled by default;
+--page-size 1`. **Decode CUDA graph is supported** (enabled by default;
 pass `--disable-decode-cuda-graph` only for a fully-eager, bit-reproducible run).
-Prefill R-KV (`--enable-rkv-prefill`) additionally needs
-`--disable-prefill-cuda-graph` and cannot combine with `--enable-rkv`. These are
-enforced at startup by `_handle_rkv_validation` / `_handle_rkv_prefill_validation`.
+**Tensor parallel (`--tp-size N`) and plain data parallel (`--dp-size N`) are
+supported**; only DP attention (`--enable-dp-attention`) is not. Prefill R-KV
+(`--enable-rkv-prefill`) additionally needs `--disable-prefill-cuda-graph` and
+cannot combine with `--enable-rkv`. Unsupported runtimes (non-FlashInfer backend,
+MLA, hybrid-SWA, speculative decoding) are rejected at startup.
 
 ---
 

--- a/SGLang/patch/rkv-sglang-0.5.14.patch
+++ b/SGLang/patch/rkv-sglang-0.5.14.patch
@@ -1,18 +1,22 @@
 diff --git a/python/sglang/srt/layers/attention/flashinfer_backend.py b/python/sglang/srt/layers/attention/flashinfer_backend.py
-index da22da628..e80af087b 100644
+index da22da628..978d641e9 100644
 --- a/python/sglang/srt/layers/attention/flashinfer_backend.py
 +++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
-@@ -305,6 +305,9 @@ class FlashInferAttnBackend(AttentionBackend):
+@@ -305,6 +305,13 @@ class FlashInferAttnBackend(AttentionBackend):
  
          self.req_to_token_pool = model_runner.req_to_token_pool
          self.token_to_kv_pool = model_runner.token_to_kv_pool
 +        # R-KV compressor (constructed in alloc_memory_pool, which runs before
 +        # attention backends are built). None when R-KV is disabled.
 +        self.rkv_compressor = getattr(model_runner, "rkv_compressor", None)
++        # R-KV prefill (prompt-phase) compressor (same construction timing).
++        self.rkv_prefill_compressor = getattr(
++            model_runner, "rkv_prefill_compressor", None
++        )
          self._swa_kv_pool: Optional[BaseSWAKVPool] = self._resolve_swa_kv_pool(
              model_runner
          )
-@@ -759,6 +762,13 @@ class FlashInferAttnBackend(AttentionBackend):
+@@ -759,6 +766,18 @@ class FlashInferAttnBackend(AttentionBackend):
              self.forward_metadata = DecodeMetadata(
                  self.decode_wrappers, swa_out_cache_loc=swa_out_cache_loc
              )
@@ -23,17 +27,23 @@ index da22da628..e80af087b 100644
 +                # after R-KV eviction.
 +                forward_batch.rkv_compressor = self.rkv_compressor
 +                self.rkv_compressor.override_decode_positions(forward_batch)
++            if self.rkv_prefill_compressor is not None:
++                # Same rationale: seq_lens tracks the shrunk physical KV length
++                # after prompt compaction; restore logical rotary positions.
++                forward_batch.rkv_prefill_compressor = self.rkv_prefill_compressor
++                self.rkv_prefill_compressor.override_decode_positions(forward_batch)
          elif forward_batch.forward_mode.is_target_verify():
              self.indices_updater_prefill.update(
                  forward_batch.req_pool_indices,
-@@ -1113,6 +1123,17 @@ class FlashInferAttnBackend(AttentionBackend):
+@@ -1080,6 +1099,18 @@ class FlashInferAttnBackend(AttentionBackend):
                      layer.v_scale,
                  )
  
-+        rkv_compressor = self.rkv_compressor
-+        if rkv_compressor is not None:
-+            # Observe this layer's decode step (cache query, accumulate score).
-+            rkv_compressor.observe_decode_layer(
++        rkv_prefill_compressor = self.rkv_prefill_compressor
++        if rkv_prefill_compressor is not None:
++            # Buffer this layer's observation-window queries (R-KV scores
++            # importance+redundancy at compaction time).
++            rkv_prefill_compressor.observe_prefill_layer(
 +                q.view(-1, layer.tp_q_head_num, layer.head_dim),
 +                k,
 +                v,
@@ -41,23 +51,321 @@ index da22da628..e80af087b 100644
 +                forward_batch,
 +            )
 +
+         return o.view(-1, layer.tp_q_head_num * layer.head_dim)
+ 
+     @debug_kernel_api
+@@ -1113,6 +1144,14 @@ class FlashInferAttnBackend(AttentionBackend):
+                     layer.v_scale,
+                 )
+ 
++        rkv_compressor = self.rkv_compressor
++        if rkv_compressor is not None:
++            q_view = q.view(-1, layer.tp_q_head_num, layer.head_dim)
++            # (1c) In-graph rolling query collection: captured in the decode
++            # graph (like set_kv_buffer), so graph-replay steps collect too.
++            # Unconditional -> capture includes it. Lets window steps stop eager.
++            rkv_compressor.collect_decode_query(q_view, layer, forward_batch)
++
          # Call the wrapped function
          o = decode_wrapper.forward(
              q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim),
+diff --git a/python/sglang/srt/managers/schedule_batch.py b/python/sglang/srt/managers/schedule_batch.py
+index f1dc81d17..515d74fd9 100755
+--- a/python/sglang/srt/managers/schedule_batch.py
++++ b/python/sglang/srt/managers/schedule_batch.py
+@@ -1612,10 +1612,19 @@ def release_req(
+     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+     tree_cache: BasePrefixCache,
+     hisparse_coordinator: Optional[HiSparseCoordinator],
++    retract_compressors: tuple = (),
+ ) -> None:
+     if hisparse_coordinator is not None and not req.finished():
+         hisparse_coordinator.retract_req(req)
+ 
++    # Drop each compressor's per-request state while req_pool_idx is still valid
++    # (req_to_token_pool.free below sets it to None). The physical KV is about to
++    # be freed; a retained state would carry stale compaction bookkeeping into
++    # the request's next prefill+decode (a prompt-phase compressor would skip
++    # re-compaction and leak KV slots; decode R-KV would mis-drive compaction).
++    for compressor in retract_compressors:
++        compressor.on_request_retract(req)
++
+     if server_args.disaggregation_mode == "decode":
+         req.offload_kv_cache(req_to_token_pool, token_to_kv_pool_allocator)
+     # TODO (csy): for preempted requests, we may want to insert into the tree
+@@ -1635,6 +1644,7 @@ def retract_all(
+     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
+     tree_cache: BasePrefixCache,
+     hisparse_coordinator: Optional[HiSparseCoordinator],
++    retract_compressors: tuple = (),
+ ) -> List[Req]:
+     retracted_reqs = reqs
+     for idx in range(len(reqs)):
+@@ -1646,6 +1656,7 @@ def retract_all(
+             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+             tree_cache=tree_cache,
+             hisparse_coordinator=hisparse_coordinator,
++            retract_compressors=retract_compressors,
+         )
+     return retracted_reqs
+ 
+@@ -1690,6 +1701,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+     # HiSparse (engine-level coordinator ref, same across batches)
+     hisparse_coordinator: Optional[HiSparseCoordinator] = None
+ 
++    # Compressors (engine-level refs, same across batches) whose per-request
++    # state must be dropped when a request is retracted, while its req_pool_idx
++    # is still valid. release_req / retract_all call on_request_retract on each.
++    retract_compressors: tuple = ()
++
+     # === Batch-variant scheduler state (per-batch; not read by ForwardBatch) ===
+     # Tell whether the current running batch is full so that we can skip
+     # the check of whether to prefill new requests.
+@@ -2451,6 +2467,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+             tree_cache=self.tree_cache,
+             hisparse_coordinator=self.hisparse_coordinator,
++            retract_compressors=self.retract_compressors,
+         )
+         self.reqs = []
+         return retracted_reqs
+@@ -2528,6 +2545,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
+             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+             tree_cache=self.tree_cache,
+             hisparse_coordinator=self.hisparse_coordinator,
++            retract_compressors=self.retract_compressors,
+         )
+ 
+     def prepare_encoder_info_decode(self):
+diff --git a/python/sglang/srt/managers/schedule_policy.py b/python/sglang/srt/managers/schedule_policy.py
+index 1b34f0f54..ec0d962b3 100644
+--- a/python/sglang/srt/managers/schedule_policy.py
++++ b/python/sglang/srt/managers/schedule_policy.py
+@@ -440,8 +440,25 @@ class PrefillAdder:
+         prefill_delayer_single_pass: Optional[PrefillDelayerSinglePassExecutor] = None,
+         dllm_config: Optional[DllmConfig] = None,
+         waiting_queue_len: int = 0,
++        rkv_compressor=None,
++        prompt_phase_compressor=None,
+     ):
+         self.page_size = page_size
++        # Decode-time R-KV compressor (or None). When set, admission reserves a
++        # request's constant physical KV ceiling (RKVCompressor.admission_reserve)
++        # instead of its full remaining max_new_tokens, so far more compressed
++        # requests can run concurrently. Assigned first because
++        # _get_running_request_total_token_offset (called below on the running
++        # batch) reads it.
++        self.rkv_compressor = rkv_compressor
++        # Prompt-phase compressor (R-KV-prefill), or None. It frees
++        # the prompt down to `budget` at the END of prefill, so a request's
++        # steady-state decode footprint is min(prompt, budget) + output. New-
++        # request admission reserves that smaller lifetime footprint (while the
++        # transient full-prompt prefill is gated on cur_rem_tokens), letting far
++        # more compressed requests run concurrently. Mutually exclusive with
++        # rkv_compressor (validated in server_args).
++        self.prompt_phase_compressor = prompt_phase_compressor
+         self.tree_cache = tree_cache
+         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+         self.running_batch = running_batch
+@@ -507,6 +524,16 @@ class PrefillAdder:
+         self.rem_dllm_tokens = max_running_reqs * self.dllm_block_size
+ 
+     def _get_running_request_total_token_offset(self, req: Req) -> int:
++        if self.rkv_compressor is not None:
++            # R-KV caps a request's physical KV at a constant ceiling regardless
++            # of how many tokens it will still generate; reserve that bound (see
++            # RKVCompressor.admission_reserve) instead of the full remaining
++            # max_new_tokens so the scheduler can admit many more concurrent
++            # requests without ever under-reserving.
++            return self.rkv_compressor.admission_reserve(
++                prompt_len=len(req.origin_input_ids),
++                occupied=req.kv_committed_len,
++            )
+         return (
+             min(
+                 (req.sampling_params.max_new_tokens - len(req.output_ids)),
+@@ -515,6 +542,19 @@ class PrefillAdder:
+             * self.new_token_ratio
+         )
+ 
++    def _admission_max_new(self, req: Req) -> int:
++        """max_new_tokens estimate used for prefill admission reservation.
++
++        For R-KV requests this is the bounded future physical increment (see
++        RKVCompressor.admission_reserve), computed against the prompt length;
++        otherwise the usual clipped remaining generation length.
++        """
++        if self.rkv_compressor is not None:
++            return self.rkv_compressor.admission_reserve(
++                prompt_len=req.extend_input_len, occupied=req.extend_input_len
++            )
++        return min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
++
+     @property
+     def rem_total_tokens(self):
+         if self.is_hybrid_swa:
+@@ -612,13 +652,26 @@ class PrefillAdder:
+         extend_input_len: int,
+         max_new_tokens: int,
+         retracted_stain: bool,
++        steady_extend_len: Optional[int] = None,
+     ):
+         # TODO(lsyin): check this workaround logic, which only ensures the prefill will not out of memory, and may be too conservative
+         extend_input_len = self.ceil_paged_tokens(extend_input_len)
+ 
++        # Prompt-phase compressors free the prompt down to `budget` at the end of
++        # prefill, so a request's LIFETIME (decode-time) footprint is
++        # steady_extend_len + max_new, while the prefill still transiently needs
++        # the full extend_input_len. Reserve them on the lifetime vs current
++        # offsets respectively. Defaults to extend_input_len (no compression).
++        if steady_extend_len is None:
++            steady_extend_len = extend_input_len
++        else:
++            steady_extend_len = self.ceil_paged_tokens(steady_extend_len)
++
+         # alloc_extend reserves an extra page_size per request to make sure the budget doesn't over-commit
+         page_overhead = self.page_size
+-        self.rem_total_token_offset += extend_input_len + max_new_tokens + page_overhead
++        self.rem_total_token_offset += (
++            steady_extend_len + max_new_tokens + page_overhead
++        )
+         self.cur_rem_token_offset += extend_input_len + page_overhead
+         self.rem_input_tokens -= extend_input_len
+ 
+@@ -763,13 +816,43 @@ class PrefillAdder:
+                 return AddReqResult.NO_TOKEN
+ 
+         def add_req_state(r, insert_sort=False):
+-            new_token_ratio = (
+-                1.0 if r.sampling_params.ignore_eos else self.new_token_ratio
+-            )
+-            tokens_left = r.sampling_params.max_new_tokens * new_token_ratio - len(
+-                r.output_ids
+-            )
+-            tokens_occupied = len(r.origin_input_ids) + len(r.output_ids)
++            if self.rkv_compressor is not None:
++                # R-KV bounds physical KV at a constant ceiling; reserve that
++                # (small) future increment and account occupancy by the physical
++                # committed length, not the ever-growing logical length.
++                occupied = (
++                    r.kv_committed_len
++                    if r.kv_committed_len > 0
++                    else len(r.origin_input_ids)
++                )
++                tokens_left = self.rkv_compressor.admission_reserve(
++                    prompt_len=len(r.origin_input_ids), occupied=occupied
++                )
++                tokens_occupied = occupied
++            elif self.prompt_phase_compressor is not None:
++                # Prompt-phase compaction frees the prompt to budget at prefill
++                # end, so steady occupancy is min(prompt, budget) + output; the
++                # future reservation is the remaining output (decode grows by 1).
++                new_token_ratio = (
++                    1.0 if r.sampling_params.ignore_eos else self.new_token_ratio
++                )
++                tokens_left = r.sampling_params.max_new_tokens * new_token_ratio - len(
++                    r.output_ids
++                )
++                tokens_occupied = (
++                    self.prompt_phase_compressor.admission_steady_prompt_len(
++                        len(r.origin_input_ids)
++                    )
++                    + len(r.output_ids)
++                )
++            else:
++                new_token_ratio = (
++                    1.0 if r.sampling_params.ignore_eos else self.new_token_ratio
++                )
++                tokens_left = r.sampling_params.max_new_tokens * new_token_ratio - len(
++                    r.output_ids
++                )
++                tokens_occupied = len(r.origin_input_ids) + len(r.output_ids)
+ 
+             if tokens_left <= 0:
+                 return
+@@ -836,7 +919,7 @@ class PrefillAdder:
+             self._update_prefill_budget(
+                 0,
+                 req.extend_input_len,
+-                min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS),
++                self._admission_max_new(req),
+                 req.retracted_stain,
+             )
+         else:
+@@ -885,11 +968,32 @@ class PrefillAdder:
+         # _update_prefill_budget already accounts for this in the deduction.
+         # Without this, admission is more optimistic than the actual budget
+         # deduction, allowing over-admission when the pool is nearly full.
+-        max_new = min(
+-            max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
+-            CLIP_MAX_NEW_TOKENS,
+-        )
+-        total_tokens = req.extend_input_len + max_new + self.page_size
++        if self.rkv_compressor is not None:
++            max_new = self.rkv_compressor.admission_reserve(
++                prompt_len=req.extend_input_len, occupied=req.extend_input_len
++            )
++            total_tokens = req.extend_input_len + max_new + self.page_size
++        elif self.prompt_phase_compressor is not None:
++            # Lifetime (decode-time) footprint after the prefill-end compaction
++            # is min(prompt, budget) + max_new. The prefill itself still needs
++            # the full prompt transiently, so gate that on cur_rem_tokens here;
++            # total_tokens below only covers the compressed lifetime footprint.
++            max_new = min(
++                max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
++                CLIP_MAX_NEW_TOKENS,
++            )
++            steady_prompt = self.prompt_phase_compressor.admission_steady_prompt_len(
++                req.extend_input_len
++            )
++            total_tokens = steady_prompt + max_new + self.page_size
++            if self.ceil_paged_tokens(req.extend_input_len) > self.cur_rem_tokens:
++                return AddReqResult.NO_TOKEN
++        else:
++            max_new = min(
++                max(req.sampling_params.max_new_tokens - len(req.output_ids), 0),
++                CLIP_MAX_NEW_TOKENS,
++            )
++            total_tokens = req.extend_input_len + max_new + self.page_size
+ 
+         # adjusting the input_tokens based on host_hit_length and page_size
+         real_input_tokens = req.extend_input_len - req.host_hit_length
+@@ -977,11 +1081,15 @@ class PrefillAdder:
+                 self._update_prefill_budget(
+                     prefix_len,
+                     input_tokens,
+-                    min(
+-                        req.sampling_params.max_new_tokens,
+-                        CLIP_MAX_NEW_TOKENS,
+-                    ),
++                    self._admission_max_new(req),
+                     req.retracted_stain,
++                    steady_extend_len=(
++                        self.prompt_phase_compressor.admission_steady_prompt_len(
++                            input_tokens
++                        )
++                        if self.prompt_phase_compressor is not None
++                        else None
++                    ),
+                 )
+             else:
+                 # Make sure at least one page is available
 diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
-index abba37441..26dbf27d3 100644
+index abba37441..22c8783fb 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
-@@ -352,6 +352,8 @@ class Scheduler(
+@@ -352,6 +352,10 @@ class Scheduler(
          self.max_recv_per_poll = envs.SGLANG_SCHEDULER_MAX_RECV_PER_POLL.get()
          self.enable_hisparse = server_args.enable_hisparse
          self.hisparse_coordinator: Optional[HiSparseCoordinator] = None
 +        self.enable_rkv = server_args.enable_rkv
 +        self.rkv_compressor = None
++        self.enable_rkv_prefill = server_args.enable_rkv_prefill
++        self.rkv_prefill_compressor = None
  
          # Set by the ShutdownReq handler to break the event loop for graceful shutdown.
          self.gracefully_exit = False
-@@ -477,6 +479,10 @@ class Scheduler(
+@@ -477,6 +481,16 @@ class Scheduler(
              self.hisparse_coordinator = self.tp_worker.model_runner.hisparse_coordinator
              self.hisparse_coordinator.set_decode_producer_stream(self.forward_stream)
  
@@ -65,10 +373,16 @@ index abba37441..26dbf27d3 100644
 +            # RKVCompressor was created inside ModelRunner.alloc_memory_pool().
 +            self.rkv_compressor = self.tp_worker.model_runner.rkv_compressor
 +
++        if self.enable_rkv_prefill:
++            # RKVPrefillCompressor was created inside ModelRunner.alloc_memory_pool().
++            self.rkv_prefill_compressor = (
++                self.tp_worker.model_runner.rkv_prefill_compressor
++            )
++
          if (
              self.server_args.disaggregation_mode == "decode"
              and self.server_args.disaggregation_decode_enable_offload_kvcache
-@@ -843,6 +849,11 @@ class Scheduler(
+@@ -843,6 +857,15 @@ class Scheduler(
                  req_to_token_pool=pool,
                  token_to_kv_pool_allocator=allocator,
              )
@@ -77,10 +391,68 @@ index abba37441..26dbf27d3 100644
 +        # it now that the pools (and the compressor) actually exist.
 +        if self.enable_rkv:
 +            self.rkv_compressor = self.tp_worker.model_runner.rkv_compressor
++        if self.enable_rkv_prefill:
++            self.rkv_prefill_compressor = (
++                self.tp_worker.model_runner.rkv_prefill_compressor
++            )
  
      def init_all_attention_backends(self):
          """Initialize attention backends for all workers."""
-@@ -3078,10 +3089,34 @@ class Scheduler(
+@@ -2791,6 +2814,11 @@ class Scheduler(
+             prefill_delayer_single_pass=prefill_delayer_single_pass,
+             dllm_config=self.dllm_config,
+             waiting_queue_len=len(self.waiting_queue),
++            rkv_compressor=self.rkv_compressor,
++            # R-KV-prefill compresses the prompt at prefill end, so admission
++            # reserves its smaller steady-state footprint
++            # (min(prompt, budget) + max_new).
++            prompt_phase_compressor=self.rkv_prefill_compressor,
+         )
+ 
+         if self.chunked_req is not None:
+@@ -2928,6 +2956,17 @@ class Scheduler(
+ 
+         new_batch.prepare_for_extend()
+ 
++        # R-KV prefill: register newly-prefilled requests now that
++        # prepare_for_extend has assigned their req_pool_idx, so the prefill
++        # forward's observation hook can find their per-request state.
++        if self.rkv_prefill_compressor is not None:
++            for req in new_batch.reqs:
++                if not self.rkv_prefill_compressor.request_wants_compression(req):
++                    continue
++                st = self.rkv_prefill_compressor.states.get(req.req_pool_idx)
++                if st is None or st.req is not req:
++                    self.rkv_prefill_compressor.on_request_begin(req)
++
+         # Record prefill stats for logging after forward.
+         new_batch.prefill_stats = PrefillStats.from_adder(
+             adder,
+@@ -2992,8 +3031,23 @@ class Scheduler(
+                 new_lora_set
+             )
+ 
++    def _retract_compressors(self) -> tuple:
++        """Active KV compressors whose per-request state must be dropped on
++        retraction (decode R-KV + prompt-phase R-KV-prefill)."""
++        return tuple(
++            c
++            for c in (
++                self.rkv_compressor,
++                self.rkv_prefill_compressor,
++            )
++            if c is not None
++        )
++
+     def update_running_batch(self, batch: ScheduleBatch) -> Optional[ScheduleBatch]:
+         """Update the current running decoding batch."""
++        # Give the batch the compressor refs so retraction (below) can drop a
++        # retracted request's compressor state before its physical KV is freed.
++        batch.retract_compressors = self._retract_compressors()
+         initial_bs = batch.batch_size()
+ 
+         batch.filter_batch()
+@@ -3078,10 +3132,75 @@ class Scheduler(
          if batch.is_empty():
              return batch
  
@@ -89,15 +461,46 @@ index abba37441..26dbf27d3 100644
 +        if self.rkv_compressor is not None:
 +            self._apply_rkv_pre_decode(batch)
 +
++        # R-KV prefill: apply the prompt-compaction physical KV length shrink to
++        # seq_lens before prepare_for_decode advances it (rotary stays logical
++        # via override_decode_positions at forward time).
++        if self.rkv_prefill_compressor is not None:
++            self._apply_rkv_prefill_pre_decode(batch)
++
          # Update batch tensors
          batch.prepare_for_decode()
          return batch
  
++    def _apply_rkv_prefill_pre_decode(self, batch: ScheduleBatch):
++        """Drain R-KV prefill's pending physical KV length shrink into the batch
++        seq_lens tensors before prepare_for_decode advances them. Requests were
++        registered at prefill time; compaction happened during the prefill
++        forward. Rotary stays logical via override_decode_positions."""
++        updates = self.rkv_prefill_compressor.take_pending_length_updates()
++        if not updates:
++            return
++        for i, req in enumerate(batch.reqs):
++            new_len = updates.get(req.req_pool_idx)
++            if new_len is not None:
++                batch.seq_lens[i] = new_len
++                batch.seq_lens_cpu[i] = new_len
++                batch.orig_seq_lens[i] = new_len
++
 +    def _apply_rkv_pre_decode(self, batch: ScheduleBatch):
 +        """Register new R-KV requests and apply the previous step's physical KV
 +        length shrink to the batch seq_lens tensors, before prepare_for_decode
 +        advances them. seq_lens tracks physical KV length; rotary stays logical
-+        via RKVCompressor.override_decode_positions at forward time."""
++        via RKVCompressor.override_decode_positions at forward time.
++
++        Ordering guarantee (why the next attention never reads a stale length):
++        this runs inside get_next_batch_to_run BEFORE ``batch.prepare_for_decode``
++        builds the next ForwardBatch (and does ``kv_committed_len += 1`` /
++        ``seq_lens += 1``). The compaction that produced these updates already
++        freed the tail slots and cleared ``req_to_token[budget:]`` in its commit
++        phase, so the physical KV is ``budget`` here; applying the shrink now,
++        before the ForwardBatch exists, means attention never sees the old
++        (longer) seq_len against the already-compacted req_to_token.
++        """
 +        for req in batch.reqs:
 +            st = self.rkv_compressor.states.get(req.req_pool_idx)
 +            if st is None or st.req is not req:
@@ -108,6 +511,16 @@ index abba37441..26dbf27d3 100644
 +        for i, req in enumerate(batch.reqs):
 +            new_len = updates.get(req.req_pool_idx)
 +            if new_len is not None:
++                # Cross-check the two length-tracking paths agree AND that this
++                # runs before prepare_for_decode: the commit set both the pending
++                # update and kv_committed_len to budget, and prepare_for_decode
++                # (which would bump kv_committed_len to budget+1) has not run yet.
++                assert new_len == req.kv_committed_len, (
++                    f"R-KV length divergence for req_pool_idx={req.req_pool_idx}: "
++                    f"pending update {new_len} != kv_committed_len "
++                    f"{req.kv_committed_len} (compaction commit / decode-length "
++                    f"ordering broken)"
++                )
 +                batch.seq_lens[i] = new_len
 +                batch.seq_lens_cpu[i] = new_len
 +                batch.orig_seq_lens[i] = new_len
@@ -115,11 +528,19 @@ index abba37441..26dbf27d3 100644
      def record_batch_in_overlap(self, batch: ScheduleBatch):
          # FIXME(lsyin): hacky way to keep a reference to avoid GPU tensors being freed by torch GC
          # NOTE: More Reliable: record all tensors into the forward stream
+@@ -3928,6 +4047,7 @@ class Scheduler(
+         if recv_req.mode == "retract" and not self.running_batch.is_empty():
+             self.running_batch.filter_batch()
+             if len(self.running_batch.reqs) != 0:
++                self.running_batch.retract_compressors = self._retract_compressors()
+                 retracted_reqs = self.running_batch.retract_all(self.server_args)
+                 for req in retracted_reqs:
+                     self._add_request_to_queue(req)
 diff --git a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
-index a9d5f0c28..dd683259b 100644
+index a9d5f0c28..6a2a1d11b 100644
 --- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
 +++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
-@@ -91,6 +91,13 @@ class SchedulerBatchResultProcessor:
+@@ -91,6 +91,20 @@ class SchedulerBatchResultProcessor:
                  req.time_stats.set_quick_finish_time()
                  if self.server_args.enable_hisparse:
                      self.hisparse_coordinator.request_finished(req)
@@ -130,10 +551,38 @@ index a9d5f0c28..dd683259b 100644
 +                )
 +                if _rkv is not None:
 +                    _rkv.on_request_end(req)
++                _rkv_prefill = getattr(
++                    getattr(self.model_worker, "model_runner", None),
++                    "rkv_prefill_compressor",
++                    None,
++                )
++                if _rkv_prefill is not None:
++                    _rkv_prefill.on_request_end(req)
                  release_kv_cache(req, self.tree_cache)
  
          # Note: Logprobs should be handled on the prefill engine.
-@@ -855,6 +862,13 @@ class SchedulerBatchResultProcessor:
+@@ -670,6 +684,20 @@ class SchedulerBatchResultProcessor:
+                 value=can_run_cuda_graph
+             )
+ 
++        # R-KV two-phase compaction COMMIT: the decode forward relocated the
++        # surviving K/V (prepare phase) and queued commit records; now that the
++        # forward has completed (a stream-synced point) apply them — free the
++        # evicted tail slots and finalize per-request length bookkeeping — BEFORE
++        # the per-request release loop below, so a request that compacted and
++        # finished in the same step frees its tail here and only its (shrunk)
++        # head in release_kv_cache (no double-free). Keeping the allocator free
++        # off the forward stream is what the two-phase split buys.
++        _rkv = getattr(
++            getattr(self.model_worker, "model_runner", None), "rkv_compressor", None
++        )
++        if _rkv is not None:
++            _rkv.commit_compactions()
++
+         self.token_to_kv_pool_allocator.free_group_begin()
+ 
+         for i, req in enumerate(batch.reqs):
+@@ -855,6 +883,20 @@ class SchedulerBatchResultProcessor:
              else:
                  if self.server_args.enable_hisparse:
                      self.hisparse_coordinator.request_finished(req)
@@ -144,32 +593,70 @@ index a9d5f0c28..dd683259b 100644
 +                )
 +                if _rkv is not None:
 +                    _rkv.on_request_end(req)
++                _rkv_prefill = getattr(
++                    getattr(self.model_worker, "model_runner", None),
++                    "rkv_prefill_compressor",
++                    None,
++                )
++                if _rkv_prefill is not None:
++                    _rkv_prefill.on_request_end(req)
                  prepare_release = getattr(
                      self.model_worker, "prepare_for_kv_cache_release", None
                  )
+diff --git a/python/sglang/srt/model_executor/forward_batch_info.py b/python/sglang/srt/model_executor/forward_batch_info.py
+index 0feeca831..403e02c19 100644
+--- a/python/sglang/srt/model_executor/forward_batch_info.py
++++ b/python/sglang/srt/model_executor/forward_batch_info.py
+@@ -801,6 +801,22 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
+         if ret.forward_mode.is_decode() or ret.forward_mode.is_target_verify():
+             if ret.positions is None:
+                 ret.positions = clamp_position(batch.seq_lens)
++            # R-KV prefill: after its prompt compaction, seq_lens tracks the
++            # shrunk PHYSICAL KV length, so clamp_position(seq_lens) would rewind
++            # rotary. Restore *logical* positions here — at ForwardBatch
++            # construction — so BOTH the eager forward and the CUDA-graph replay
++            # (which copies forward_batch.positions into its graph input buffer)
++            # see the correct positions. No-op when R-KV prefill is off or idle.
++            rkv_prefill_comp = getattr(model_runner, "rkv_prefill_compressor", None)
++            if rkv_prefill_comp is not None and rkv_prefill_comp.states:
++                rkv_prefill_comp.override_decode_positions(ret)
++            # R-KV decode: same again — mid-generation eviction shrinks seq_lens,
++            # so restore logical positions at construction. This is what lets the
++            # decode CUDA graph stay on for R-KV (graph-replay steps copy
++            # forward_batch.positions into the graph input buffer).
++            rkv_comp = getattr(model_runner, "rkv_compressor", None)
++            if rkv_comp is not None and rkv_comp.states:
++                rkv_comp.override_decode_positions(ret)
+         else:
+             if isinstance(extend_seq_lens, list):
+                 # Main path: H2D from host lists; populate *_cpu mirrors.
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index 1cff5c983..740a9254f 100644
+index 1cff5c983..c2ed9133f 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
-@@ -417,6 +417,7 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -417,6 +417,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
          self.init_new_workspace = False
          self.draft_model_idx = draft_model_idx
          self.enable_hisparse = server_args.enable_hisparse
 +        self.enable_rkv = server_args.enable_rkv
++        self.enable_rkv_prefill = server_args.enable_rkv_prefill
  
          self.remote_instance_transfer_engine = None
          self.remote_instance_transfer_engine_session_id = ""
-@@ -566,6 +567,9 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -566,6 +568,12 @@ class ModelRunner(ModelRunnerKVCacheMixin):
          # For hisparse (must be set before initialize() so CUDA graph capture can see it)
          self.hisparse_coordinator = None
  
 +        # For R-KV decoding-time KV compression (constructed in alloc_memory_pool).
 +        self.rkv_compressor = None
 +
++        # For R-KV prefill (prompt-phase) KV compression (constructed in alloc_memory_pool).
++        self.rkv_prefill_compressor = None
++
          self._linear_attn_registry_cache: Any = _UNSET
  
          # Load model weights and configure
-@@ -846,6 +850,38 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -846,6 +854,67 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                  host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
              )
  
@@ -203,12 +690,64 @@ index 1cff5c983..740a9254f 100644
 +                start_layer=self.start_layer,
 +                end_layer=self.start_layer + self.num_effective_layers,
 +                device=self.device,
++                q_head_num=self.model_config.get_num_attention_heads(self.tp_size),
++                head_dim=self.model_config.head_dim,
++                q_dtype=self.model_config.dtype,
++                fused_validation=sa.rkv_fused_validation,
++            )
++
++        if self.enable_rkv_prefill:
++            import json
++
++            from sglang.srt.mem_cache.rkv.prefill_integration import (
++                RKVPrefillCompressor,
++                RKVPrefillConfig,
++            )
++
++            rkv_prefill_cfg_dict = {}
++            if self.server_args.rkv_prefill_config:
++                rkv_prefill_cfg_dict.update(
++                    json.loads(self.server_args.rkv_prefill_config)
++                )
++            self.rkv_prefill_compressor = RKVPrefillCompressor(
++                config=RKVPrefillConfig(**rkv_prefill_cfg_dict),
++                req_to_token_pool=self.req_to_token_pool,
++                token_to_kv_pool=self.token_to_kv_pool,
++                kv_allocator=self.token_to_kv_pool_allocator,
++                start_layer=self.start_layer,
++                end_layer=self.start_layer + self.num_effective_layers,
++                device=self.device,
++                enable_overlap=not self.server_args.disable_overlap_schedule,
++                fused_validation=self.server_args.rkv_fused_validation,
 +            )
 +
          self.init_routed_experts_capturer()
          self.init_indexer_capturer()
  
-@@ -3072,6 +3108,15 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -3001,10 +3070,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+                 if self.device == "cpu"
+                 else forward_batch.forward_mode.is_cuda_graph
+             )
++            # R-KV decode: advance per-request compaction counters EVERY decode
++            # step (this must run even on graph-replay steps) and force this step
++            # to run eager ONLY when it is a compaction step, so maybe_compact
++            # executes (it runs on the eager path; the graph path returns before
++            # it). Observation-window queries are collected in-graph by
++            # collect_decode_query, so the window steps replay the captured graph.
++            rkv_force_eager = (
++                forward_batch.forward_mode.is_decode()
++                and self.rkv_compressor is not None
++                and self.rkv_compressor.begin_decode_step(forward_batch)
++            )
+             can_run_graph = bool(
+                 mode_check()
+                 and self.decode_cuda_graph_runner
+                 and self.decode_cuda_graph_runner.can_run_graph(forward_batch)
++                and not rkv_force_eager
+             )
+ 
+             if (
+@@ -3072,6 +3153,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
              ):
                  forward_batch.post_forward_mlp_sync_batch(ret)
  
@@ -221,14 +760,195 @@ index 1cff5c983..740a9254f 100644
 +                # req_to_token, updates per-request physical lengths).
 +                self.rkv_compressor.maybe_compact(forward_batch)
 +
++            if (
++                forward_batch.forward_mode.is_extend()
++                and self.rkv_prefill_compressor is not None
++            ):
++                # The full prompt KV for every prefilled request has been
++                # written; run R-KV prefill compaction now (score the
++                # observation window with R-KV importance+redundancy, keep the
++                # budget, free the rest, rewrite req_to_token, shrink lengths).
++                self.rkv_prefill_compressor.maybe_compact(forward_batch)
++
              return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
  
      def _preprocess_logits(
+diff --git a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+index db4c8ad8e..10a3a688d 100644
+--- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
++++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
+@@ -1015,6 +1015,24 @@ class ModelRunnerKVCacheMixin:
+                 requested_per_worker,
+                 max_num_reqs,
+             )
++
++        # R-KV: optionally cap the concurrent decode requests to shrink the fixed
++        # rolling observation-query buffer. Every --enable-rkv request is an R-KV
++        # request, so the decode concurrency IS the rolling_q row count
++        # (rolling_q rows == req_to_token rows == max_running_requests + 1).
++        # Capping here cascades to the req_to_token pool, rolling_q, and the
++        # aux-memory reservation (_reserve_rkv_decode_aux_bytes, which calls this
++        # method for its provisional row count). Trades peak concurrency for
++        # memory.
++        rkv_cap = getattr(self.server_args, "rkv_max_active_requests", None)
++        if self.enable_rkv and rkv_cap is not None and max_num_reqs > rkv_cap:
++            logger.info(
++                "R-KV: capping max_running_requests %d -> %d "
++                "(--rkv-max-active-requests) to shrink the rolling-query buffer.",
++                max_num_reqs,
++                rkv_cap,
++            )
++            max_num_reqs = rkv_cap
+         return max_num_reqs
+ 
+     def _apply_memory_pool_config(self: ModelRunner, config: MemoryPoolConfig):
+@@ -1048,6 +1066,125 @@ class ModelRunnerKVCacheMixin:
+ 
+         self._init_pools()
+ 
++    @staticmethod
++    def _rkv_rolling_q_bytes(
++        num_layers: int,
++        window_size: int,
++        num_rows: int,
++        q_head_num: int,
++        head_dim: int,
++        elem_size: int,
++    ) -> int:
++        """Byte size of the R-KV decode rolling observation-query buffer.
++
++        Mirrors the allocation in
++        ``sglang.srt.mem_cache.rkv.integration.RKVCompressor.__init__``
++        (``zeros((num_layers, window_size, num_rows, q_head_num, head_dim))``).
++        Pure arithmetic so it is unit-testable without a GPU.
++        """
++        return (
++            int(num_layers)
++            * int(window_size)
++            * int(num_rows)
++            * int(q_head_num)
++            * int(head_dim)
++            * int(elem_size)
++        )
++
++    def _reserve_rkv_decode_aux_bytes(
++        self: ModelRunner, configurator, available_bytes: int, page_size: int
++    ) -> int:
++        """Subtract the R-KV decode rolling-query buffer from the KV budget.
++
++        ``RKVCompressor.rolling_q`` is allocated AFTER the KV pool, out of the
++        SAME GPU budget, with one row per request-pool slot
++        (``max_running_requests + 1``). It is never counted by the KV-slot
++        admission accounting (which only tracks pool tokens), so unless it is
++        reserved here it is charged against the post-pool headroom and can OOM
++        at startup or steal CUDA-graph capture space.
++
++        ``max_running_requests`` is only finalized from the pool size, so we use
++        the value it WOULD resolve to from the un-reserved budget as a safe
++        upper bound: reserving shrinks the budget, which can only keep or lower
++        the final count, so the real buffer never exceeds this reservation.
++        Returns the reduced ``available_bytes`` (kept strictly positive).
++        """
++        # Provisional request-pool row count from the un-reserved budget.
++        prov_tokens = configurator.calculate_pool_sizes(
++            available_bytes, page_size
++        ).max_total_num_tokens
++        num_rows = self._resolve_max_num_reqs(prov_tokens) + 1  # +1 padding row
++
++        window_size = self.server_args.rkv_window_size
++        if self.server_args.rkv_config:
++            import json
++
++            window_size = json.loads(self.server_args.rkv_config).get(
++                "window_size", window_size
++            )
++
++        q_head_num = self.model_config.get_num_attention_heads(self.tp_size)
++        rolling_bytes = self._rkv_rolling_q_bytes(
++            num_layers=self.num_effective_layers,
++            window_size=window_size,
++            num_rows=num_rows,
++            q_head_num=q_head_num,
++            head_dim=self.model_config.head_dim,
++            elem_size=torch._utils._element_size(self.model_config.dtype),
++        )
++
++        # Compaction workspace: the transient scoring tensors (cosine matrix +
++        # gathered keys) and relocation clones a compaction allocates. Because
++        # compactions run sequentially (one request at a time in maybe_compact),
++        # the peak is a single request's workspace, capped by the score-chunk
++        # bound; reserve it (+25% for the first-compaction A/B gate and caching-
++        # allocator retention) so a compaction never OOMs on transients when the
++        # KV pool is full — the KV-slot admission accounting does not cover it.
++        from sglang.srt.mem_cache.rkv.integration import RKV_SCORE_CHUNK_BYTES
++
++        workspace_bytes = RKV_SCORE_CHUNK_BYTES + (RKV_SCORE_CHUNK_BYTES >> 2)
++        aux_bytes = rolling_bytes + workspace_bytes
++
++        reduced = available_bytes - aux_bytes
++        min_keep = getattr(configurator, "_cell_size", 0) or (1 << 20)
++        if reduced < min_keep:
++            logger.warning(
++                "R-KV decode aux memory (%.2f GiB rolling-query + %.2f GiB "
++                "compaction workspace) is too large for the KV budget (%.2f "
++                "GiB); clamping its reservation. Lower --max-running-requests "
++                "or --rkv-window-size.",
++                rolling_bytes / (1 << 30),
++                workspace_bytes / (1 << 30),
++                available_bytes / (1 << 30),
++            )
++            reduced = min_keep
++        logger.info(
++            "R-KV decode: reserving %.2f GiB (%.2f GiB rolling-query buffer, "
++            "%d rows x %d layers x window %d x %d heads x %d dim; + %.2f GiB "
++            "compaction workspace); KV budget %.2f -> %.2f GiB.",
++            aux_bytes / (1 << 30),
++            rolling_bytes / (1 << 30),
++            num_rows,
++            self.num_effective_layers,
++            window_size,
++            q_head_num,
++            self.model_config.head_dim,
++            workspace_bytes / (1 << 30),
++            available_bytes / (1 << 30),
++            reduced / (1 << 30),
++        )
++        if getattr(
++            self.server_args, "rkv_max_active_requests", None
++        ) is None and rolling_bytes >= (1 << 30):
++            logger.info(
++                "R-KV: the rolling-query buffer is %.2f GiB (%d concurrent "
++                "requests). Set --rkv-max-active-requests to cap concurrency and "
++                "shrink it ~linearly if you are memory-bound.",
++                aux_bytes / (1 << 30),
++                num_rows - 1,
++            )
++        return reduced
++
+     def _resolve_memory_pool_config(
+         self: ModelRunner, pre_model_load_memory: int
+     ) -> MemoryPoolConfig:
+@@ -1060,6 +1197,15 @@ class ModelRunnerKVCacheMixin:
+         page_size = self.server_args.page_size
+ 
+         configurator = create_memory_pool_configurator(self)
++
++        # Reserve the R-KV decode rolling-query buffer up front so the KV pool
++        # leaves room for it (it is allocated afterwards from the same budget
++        # and is invisible to the KV-slot admission accounting).
++        if self.enable_rkv and not self.is_draft_worker:
++            available_bytes = self._reserve_rkv_decode_aux_bytes(
++                configurator, available_bytes, page_size
++            )
++
+         config = configurator.calculate_pool_sizes(available_bytes, page_size)
+ 
+         # Apply external constraints (user cap, page alignment, PP sync)
 diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
-index c7162c16d..a31399b92 100644
+index c7162c16d..079621c32 100644
 --- a/python/sglang/srt/server_args.py
 +++ b/python/sglang/srt/server_args.py
-@@ -1848,6 +1848,49 @@ class ServerArgs:
+@@ -1848,6 +1848,77 @@ class ServerArgs:
          ),
      ] = None
  
@@ -238,20 +958,16 @@ index c7162c16d..a31399b92 100644
 +    enable_rkv: A[bool, "Enable R-KV decoding-time KV cache compression"] = False
 +    # Per-field R-KV hyper-parameters. Defaults mirror RKVConfig. Any field left
 +    # at its default is overridable by --rkv-config JSON (which takes priority).
-+    rkv_budget: A[
-+        int, "R-KV: KV entries kept per request after compression."
-+    ] = 1024
-+    rkv_window_size: A[
-+        int, "R-KV: trailing observation window always retained."
-+    ] = 8
-+    rkv_kernel_size: A[
-+        int, "R-KV: pooling kernel size for importance smoothing."
-+    ] = 7
++    rkv_budget: A[int, "R-KV: KV entries kept per request after compression."] = 1024
++    rkv_window_size: A[int, "R-KV: trailing observation window always retained."] = 8
++    rkv_kernel_size: A[int, "R-KV: pooling kernel size for importance smoothing."] = 7
 +    rkv_mix_lambda: A[
-+        float, "R-KV: importance vs redundancy mix (0=redundancy only, 1=importance only)."
++        float,
++        "R-KV: importance vs redundancy mix (0=redundancy only, 1=importance only).",
 +    ] = 0.1
 +    rkv_retain_ratio: A[
-+        float, "R-KV: fraction of most-recent similar neighbours exempted from redundancy."
++        float,
++        "R-KV: fraction of most-recent similar neighbours exempted from redundancy.",
 +    ] = 0.1
 +    rkv_retain_direction: A[
 +        str,
@@ -274,20 +990,54 @@ index c7162c16d..a31399b92 100644
 +            aliases=["--rkv-extra-config"],
 +        ),
 +    ] = None
++    rkv_max_active_requests: A[
++        Optional[int],
++        "R-KV: cap on concurrently-decoding R-KV requests. Caps max_running_requests "
++        "when --enable-rkv, which linearly shrinks the fixed rolling observation-query "
++        "buffer (rolling_q ~ this count x layers x window x heads x head_dim). Trades "
++        "peak decode concurrency for memory; leave unset to keep the auto-resolved "
++        "max_running_requests.",
++    ] = None
++    rkv_fused_validation: A[
++        str,
++        Arg(
++            help="R-KV: when to validate the fused Triton redundancy kernel against "
++            "the reference. 'startup' validates once at load with a synthetic tensor "
++            "(no first-request cost); 'first-request' validates lazily on the first "
++            "real compaction; 'off' never uses the fused kernel (always reference). "
++            "Applies to both --enable-rkv and --enable-rkv-prefill.",
++            choices=["startup", "first-request", "off"],
++        ),
++    ] = "startup"
++
++    # -------------------------------------------------------------------------
++    # R-KV prefill (prompt-phase KV compression using R-KV importance+redundancy)
++    # -------------------------------------------------------------------------
++    enable_rkv_prefill: A[
++        bool, "Enable R-KV prompt-phase (prefill) KV cache compression"
++    ] = False
++    rkv_prefill_config: A[
++        Optional[str],
++        Arg(
++            help='A dictionary in JSON string format configuring R-KV prefill compression (fields mirror RKVPrefillConfig). Example: \'{"mode": "oneshot", "budget": 1024, "window_size": 32, "mix_lambda": 0.1, "buffer": 512}\'. mode is "oneshot" (route A) or "buffered" (route B).',
++        ),
++    ] = None
 +
      # -------------------------------------------------------------------------
      # LMCache
      # -------------------------------------------------------------------------
-@@ -2507,6 +2550,8 @@ class ServerArgs:
+@@ -2507,6 +2578,10 @@ class ServerArgs:
  
          self._handle_cuda_graph_config()
  
 +        self._handle_rkv_validation()
 +
++        self._handle_rkv_prefill_validation()
++
          # Handle device-specific backends.
          self._handle_hpu_backends()
          self._handle_cpu_backends()
-@@ -2917,6 +2962,36 @@ class ServerArgs:
+@@ -2917,6 +2992,97 @@ class ServerArgs:
          self._apply_cuda_graph_compatibility()
          self._validate_cuda_graph_config()
  
@@ -296,9 +1046,15 @@ index c7162c16d..a31399b92 100644
 +
 +        See R-KV/doc/DESIGN.md: R-KV physically frees KV slots mid-generation,
 +        which is incompatible with prefix caching (the radix tree would keep
-+        references into freed slots), captured decode CUDA graphs (eviction is
-+        dynamic), page_size > 1 (per-slot free), overlap scheduling (phase 1),
-+        and TP > 1 (per-rank eviction would diverge).
++        references into freed slots), page_size > 1 (per-slot free), overlap
++        scheduling (phase 1), and TP > 1 (per-rank eviction would diverge).
++
++        Decode CUDA graph IS supported: a per-step hook
++        (``RKVCompressor.begin_decode_step``) advances the compaction counters
++        on every step and forces the ``window_size`` steps ending at each
++        compaction (plus the compaction step) to run eager, while all other
++        decode steps replay the captured graph; logical positions are restored
++        at ForwardBatch construction so graph-replay steps see them too.
 +        """
 +        if not self.enable_rkv:
 +            return
@@ -306,11 +1062,6 @@ index c7162c16d..a31399b92 100644
 +            raise ValueError(
 +                "--enable-rkv requires --disable-radix-cache: R-KV frees KV "
 +                "slots that the radix/prefix cache would still reference."
-+            )
-+        if not (self.disable_decode_cuda_graph or self.disable_cuda_graph):
-+            raise ValueError(
-+                "--enable-rkv requires --disable-decode-cuda-graph: dynamic "
-+                "eviction cannot run inside a captured CUDA graph."
 +            )
 +        if not self.disable_overlap_schedule:
 +            raise ValueError(
@@ -320,6 +1071,66 @@ index c7162c16d..a31399b92 100644
 +            raise ValueError("--enable-rkv requires --page-size 1 (per-slot free).")
 +        if self.tp_size > 1:
 +            raise ValueError("--enable-rkv does not support tensor parallelism yet.")
++        if (
++            self.rkv_max_active_requests is not None
++            and self.rkv_max_active_requests <= 0
++        ):
++            raise ValueError("--rkv-max-active-requests must be a positive integer.")
++
++    def _handle_rkv_prefill_validation(self):
++        """Enforce the invariants R-KV prefill compression depends on.
++
++        R-KV prefill physically frees prompt KV slots right after prefill, so
++        it needs prefix caching off, the prefill CUDA graph off
++        (prompt-phase scoring/compaction are dynamic), overlap scheduling off,
++        page_size 1, and TP == 1.
++        Overlap scheduling is NOT supported: the prefill-end compaction frees KV
++        slots from inside the forward (on the forward stream), which races with
++        the overlap scheduler's async next-batch allocation on the same
++        ``free_pages`` tensor (default stream) — a torn read yields garbage slot
++        indices and an illegal memory access at scale. This is the same reason
++        the decode R-KV compressor requires overlap off. (seq_lens / rotary
++        positions are already overlap-correct; the allocator free is the blocker.)
++        Decode CUDA graph IS supported (logical positions restored
++        at ForwardBatch construction). It is mutually exclusive with the decode
++        R-KV compressor (both own physical-length / rotary
++        bookkeeping). ``mode='buffered'`` (route B) does its segmented eviction
++        logically during prefill and one physical compaction at the end, so it
++        supports chunked prefill just like ``oneshot``.
++        """
++        if not self.enable_rkv_prefill:
++            return
++        if self.enable_rkv:
++            raise ValueError(
++                "--enable-rkv-prefill cannot be combined with --enable-rkv."
++            )
++        if not self.disable_radix_cache:
++            raise ValueError(
++                "--enable-rkv-prefill requires --disable-radix-cache: it frees KV "
++                "slots the radix/prefix cache would still reference."
++            )
++        if not (self.disable_prefill_cuda_graph or self.disable_cuda_graph):
++            raise ValueError(
++                "--enable-rkv-prefill requires --disable-prefill-cuda-graph: the "
++                "prompt-phase scoring and compaction are dynamic. (Decode CUDA "
++                "graph is supported and may stay enabled.)"
++            )
++        if not self.disable_overlap_schedule:
++            raise ValueError(
++                "--enable-rkv-prefill requires --disable-overlap-schedule: the "
++                "prefill-end compaction frees KV slots from inside the forward "
++                "(forward stream), which races with the overlap scheduler's "
++                "async next-batch allocation on the free-list (default stream) "
++                "and causes an illegal memory access at scale."
++            )
++        if self.page_size not in (None, 1):
++            raise ValueError(
++                "--enable-rkv-prefill requires --page-size 1 (per-slot free)."
++            )
++        if self.tp_size > 1:
++            raise ValueError(
++                "--enable-rkv-prefill does not support tensor parallelism yet."
++            )
 +
      def _parse_cuda_graph_config(self):
          """Resolve cuda_graph_config from explicit JSON, per-phase

--- a/SGLang/patch/rkv-sglang-0.5.14.patch
+++ b/SGLang/patch/rkv-sglang-0.5.14.patch
@@ -351,7 +351,7 @@ index 1b34f0f54..ec0d962b3 100644
              else:
                  # Make sure at least one page is available
 diff --git a/python/sglang/srt/managers/scheduler.py b/python/sglang/srt/managers/scheduler.py
-index abba37441..22c8783fb 100644
+index abba37441..be7a1405c 100644
 --- a/python/sglang/srt/managers/scheduler.py
 +++ b/python/sglang/srt/managers/scheduler.py
 @@ -352,6 +352,10 @@ class Scheduler(
@@ -452,7 +452,7 @@ index abba37441..22c8783fb 100644
          initial_bs = batch.batch_size()
  
          batch.filter_batch()
-@@ -3078,10 +3132,75 @@ class Scheduler(
+@@ -3078,10 +3132,95 @@ class Scheduler(
          if batch.is_empty():
              return batch
  
@@ -480,11 +480,20 @@ index abba37441..22c8783fb 100644
 +        if not updates:
 +            return
 +        for i, req in enumerate(batch.reqs):
-+            new_len = updates.get(req.req_pool_idx)
-+            if new_len is not None:
-+                batch.seq_lens[i] = new_len
-+                batch.seq_lens_cpu[i] = new_len
-+                batch.orig_seq_lens[i] = new_len
++            upd = updates.get(req.req_pool_idx)
++            if upd is None:
++                continue
++            new_len, owner = upd
++            # Identity guard: skip an update whose pool slot was released/reused
++            # between the compaction and this drain (it belongs to a dead
++            # request). Without this a reused req_pool_idx would have the new
++            # occupant's seq_lens blindly rewritten to the old budget, letting
++            # attention read cleared/unallocated KV.
++            if owner is not req:
++                continue
++            batch.seq_lens[i] = new_len
++            batch.seq_lens_cpu[i] = new_len
++            batch.orig_seq_lens[i] = new_len
 +
 +    def _apply_rkv_pre_decode(self, batch: ScheduleBatch):
 +        """Register new R-KV requests and apply the previous step's physical KV
@@ -509,26 +518,37 @@ index abba37441..22c8783fb 100644
 +        if not updates:
 +            return
 +        for i, req in enumerate(batch.reqs):
-+            new_len = updates.get(req.req_pool_idx)
-+            if new_len is not None:
-+                # Cross-check the two length-tracking paths agree AND that this
-+                # runs before prepare_for_decode: the commit set both the pending
-+                # update and kv_committed_len to budget, and prepare_for_decode
-+                # (which would bump kv_committed_len to budget+1) has not run yet.
-+                assert new_len == req.kv_committed_len, (
++            upd = updates.get(req.req_pool_idx)
++            if upd is None:
++                continue
++            new_len, owner = upd
++            # Identity guard: a pending update whose pool slot was released and
++            # reused between commit and this drain belongs to a dead request.
++            # Skip it rather than rewrite the new occupant's seq_lens (which,
++            # under python -O with the check below stripped, would silently
++            # corrupt the reused request's length).
++            if owner is not req:
++                continue
++            # Cross-check the two length-tracking paths agree AND that this runs
++            # before prepare_for_decode: the commit set both the pending update
++            # and kv_committed_len to budget, and prepare_for_decode (which would
++            # bump kv_committed_len to budget+1) has not run yet. This is a hard
++            # invariant, so raise (not a debug assert that -O would strip).
++            if new_len != req.kv_committed_len:
++                raise RuntimeError(
 +                    f"R-KV length divergence for req_pool_idx={req.req_pool_idx}: "
 +                    f"pending update {new_len} != kv_committed_len "
 +                    f"{req.kv_committed_len} (compaction commit / decode-length "
 +                    f"ordering broken)"
 +                )
-+                batch.seq_lens[i] = new_len
-+                batch.seq_lens_cpu[i] = new_len
-+                batch.orig_seq_lens[i] = new_len
++            batch.seq_lens[i] = new_len
++            batch.seq_lens_cpu[i] = new_len
++            batch.orig_seq_lens[i] = new_len
 +
      def record_batch_in_overlap(self, batch: ScheduleBatch):
          # FIXME(lsyin): hacky way to keep a reference to avoid GPU tensors being freed by torch GC
          # NOTE: More Reliable: record all tensors into the forward stream
-@@ -3928,6 +4047,7 @@ class Scheduler(
+@@ -3928,6 +4067,7 @@ class Scheduler(
          if recv_req.mode == "retract" and not self.running_batch.is_empty():
              self.running_batch.filter_batch()
              if len(self.running_batch.reqs) != 0:
@@ -537,31 +557,49 @@ index abba37441..22c8783fb 100644
                  for req in retracted_reqs:
                      self._add_request_to_queue(req)
 diff --git a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
-index a9d5f0c28..6a2a1d11b 100644
+index a9d5f0c28..67501c680 100644
 --- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
 +++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
-@@ -91,6 +91,20 @@ class SchedulerBatchResultProcessor:
+@@ -79,6 +79,22 @@ class SchedulerBatchResultProcessor:
+     output_streamer: SchedulerOutputStreamer
+     abort_request: Callable
+ 
++    def _rkv_on_request_finished(self, req: Req) -> None:
++        """Notify the R-KV compressors that a request finished so they drop its
++        per-request state AND any pending compaction bookkeeping.
++
++        Must be called on EVERY path that releases a finished request's pool
++        slot -- including the normal ``process_batch_result_prefill`` finish path
++        -- otherwise a request that compacts and finishes on the same step
++        leaves a stale pending length update that gets applied to the next
++        request reusing its ``req_pool_idx``.
++        """
++        model_runner = getattr(self.model_worker, "model_runner", None)
++        for attr in ("rkv_compressor", "rkv_prefill_compressor"):
++            comp = getattr(model_runner, attr, None)
++            if comp is not None:
++                comp.on_request_end(req)
++
+     def process_batch_result_prebuilt(self, batch: ScheduleBatch):
+         assert self.disaggregation_mode == DisaggregationMode.DECODE
+         use_free_group = self.server_args.disaggregation_decode_enable_radix_cache
+@@ -91,6 +107,7 @@ class SchedulerBatchResultProcessor:
                  req.time_stats.set_quick_finish_time()
                  if self.server_args.enable_hisparse:
                      self.hisparse_coordinator.request_finished(req)
-+                _rkv = getattr(
-+                    getattr(self.model_worker, "model_runner", None),
-+                    "rkv_compressor",
-+                    None,
-+                )
-+                if _rkv is not None:
-+                    _rkv.on_request_end(req)
-+                _rkv_prefill = getattr(
-+                    getattr(self.model_worker, "model_runner", None),
-+                    "rkv_prefill_compressor",
-+                    None,
-+                )
-+                if _rkv_prefill is not None:
-+                    _rkv_prefill.on_request_end(req)
++                self._rkv_on_request_finished(req)
                  release_kv_cache(req, self.tree_cache)
  
          # Note: Logprobs should be handled on the prefill engine.
-@@ -670,6 +684,20 @@ class SchedulerBatchResultProcessor:
+@@ -236,6 +253,7 @@ class SchedulerBatchResultProcessor:
+                     if req.finished():
+                         self._maybe_collect_routed_experts(req)
+                         self._maybe_collect_indexer_topk(req)
++                        self._rkv_on_request_finished(req)
+                         release_kv_cache(req, self.tree_cache)
+                         req.time_stats.set_completion_time()
+                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
+@@ -670,6 +688,20 @@ class SchedulerBatchResultProcessor:
                  value=can_run_cuda_graph
              )
  
@@ -582,24 +620,11 @@ index a9d5f0c28..6a2a1d11b 100644
          self.token_to_kv_pool_allocator.free_group_begin()
  
          for i, req in enumerate(batch.reqs):
-@@ -855,6 +883,20 @@ class SchedulerBatchResultProcessor:
+@@ -855,6 +887,7 @@ class SchedulerBatchResultProcessor:
              else:
                  if self.server_args.enable_hisparse:
                      self.hisparse_coordinator.request_finished(req)
-+                _rkv = getattr(
-+                    getattr(self.model_worker, "model_runner", None),
-+                    "rkv_compressor",
-+                    None,
-+                )
-+                if _rkv is not None:
-+                    _rkv.on_request_end(req)
-+                _rkv_prefill = getattr(
-+                    getattr(self.model_worker, "model_runner", None),
-+                    "rkv_prefill_compressor",
-+                    None,
-+                )
-+                if _rkv_prefill is not None:
-+                    _rkv_prefill.on_request_end(req)
++                self._rkv_on_request_finished(req)
                  prepare_release = getattr(
                      self.model_worker, "prepare_for_kv_cache_release", None
                  )
@@ -631,7 +656,7 @@ index 0feeca831..403e02c19 100644
              if isinstance(extend_seq_lens, list):
                  # Main path: H2D from host lists; populate *_cpu mirrors.
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index 1cff5c983..c2ed9133f 100644
+index 1cff5c983..071dd303b 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
 @@ -417,6 +417,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
@@ -656,7 +681,7 @@ index 1cff5c983..c2ed9133f 100644
          self._linear_attn_registry_cache: Any = _UNSET
  
          # Load model weights and configure
-@@ -846,6 +854,67 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -846,6 +854,99 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                  host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
              )
  
@@ -666,9 +691,24 @@ index 1cff5c983..c2ed9133f 100644
 +            from sglang.srt.mem_cache.rkv.integration import (
 +                RKVCompressor,
 +                RKVConfig,
++                rkv_runtime_support_error,
 +            )
 +
 +            sa = self.server_args
++            # Late, post-resolution hard gate: ServerArgs validation ran before
++            # the backend/model/page-size/spec were resolved. Fail now if the
++            # actual runtime is not one the R-KV hooks are wired for.
++            _rkv_reason = rkv_runtime_support_error(
++                mode="decode",
++                prefill_backend=sa.prefill_attention_backend or sa.attention_backend,
++                decode_backend=sa.decode_attention_backend or sa.attention_backend,
++                use_mla=self.use_mla_backend,
++                is_hybrid_swa=self.is_hybrid_swa,
++                spec_enabled=not self.spec_algorithm.is_none(),
++                page_size=sa.page_size,
++            )
++            if _rkv_reason is not None:
++                raise ValueError(_rkv_reason)
 +            # Base config from the per-field flags; --rkv-config JSON overrides.
 +            rkv_cfg_dict = {
 +                "budget": sa.rkv_budget,
@@ -694,16 +734,32 @@ index 1cff5c983..c2ed9133f 100644
 +                head_dim=self.model_config.head_dim,
 +                q_dtype=self.model_config.dtype,
 +                fused_validation=sa.rkv_fused_validation,
++                attn_tp_group=self.attention_tp_group,
 +            )
 +
 +        if self.enable_rkv_prefill:
 +            import json
 +
++            from sglang.srt.mem_cache.rkv.integration import (
++                rkv_runtime_support_error,
++            )
 +            from sglang.srt.mem_cache.rkv.prefill_integration import (
 +                RKVPrefillCompressor,
 +                RKVPrefillConfig,
 +            )
 +
++            sa = self.server_args
++            _rkv_reason = rkv_runtime_support_error(
++                mode="prefill",
++                prefill_backend=sa.prefill_attention_backend or sa.attention_backend,
++                decode_backend=sa.decode_attention_backend or sa.attention_backend,
++                use_mla=self.use_mla_backend,
++                is_hybrid_swa=self.is_hybrid_swa,
++                spec_enabled=not self.spec_algorithm.is_none(),
++                page_size=sa.page_size,
++            )
++            if _rkv_reason is not None:
++                raise ValueError(_rkv_reason)
 +            rkv_prefill_cfg_dict = {}
 +            if self.server_args.rkv_prefill_config:
 +                rkv_prefill_cfg_dict.update(
@@ -719,12 +775,13 @@ index 1cff5c983..c2ed9133f 100644
 +                device=self.device,
 +                enable_overlap=not self.server_args.disable_overlap_schedule,
 +                fused_validation=self.server_args.rkv_fused_validation,
++                attn_tp_group=self.attention_tp_group,
 +            )
 +
          self.init_routed_experts_capturer()
          self.init_indexer_capturer()
  
-@@ -3001,10 +3070,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -3001,10 +3102,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                  if self.device == "cpu"
                  else forward_batch.forward_mode.is_cuda_graph
              )
@@ -747,7 +804,7 @@ index 1cff5c983..c2ed9133f 100644
              )
  
              if (
-@@ -3072,6 +3153,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -3072,6 +3185,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
              ):
                  forward_batch.post_forward_mlp_sync_batch(ret)
  
@@ -774,7 +831,7 @@ index 1cff5c983..c2ed9133f 100644
  
      def _preprocess_logits(
 diff --git a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
-index db4c8ad8e..10a3a688d 100644
+index db4c8ad8e..5aef18eaa 100644
 --- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
 +++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
 @@ -1015,6 +1015,24 @@ class ModelRunnerKVCacheMixin:
@@ -802,7 +859,7 @@ index db4c8ad8e..10a3a688d 100644
          return max_num_reqs
  
      def _apply_memory_pool_config(self: ModelRunner, config: MemoryPoolConfig):
-@@ -1048,6 +1066,125 @@ class ModelRunnerKVCacheMixin:
+@@ -1048,6 +1066,132 @@ class ModelRunnerKVCacheMixin:
  
          self._init_pools()
  
@@ -888,16 +945,23 @@ index db4c8ad8e..10a3a688d 100644
 +        reduced = available_bytes - aux_bytes
 +        min_keep = getattr(configurator, "_cell_size", 0) or (1 << 20)
 +        if reduced < min_keep:
-+            logger.warning(
-+                "R-KV decode aux memory (%.2f GiB rolling-query + %.2f GiB "
-+                "compaction workspace) is too large for the KV budget (%.2f "
-+                "GiB); clamping its reservation. Lower --max-running-requests "
-+                "or --rkv-window-size.",
-+                rolling_bytes / (1 << 30),
-+                workspace_bytes / (1 << 30),
-+                available_bytes / (1 << 30),
++            # Do NOT clamp: shrinking the KV pool to one cell does not shrink the
++            # actual rolling_q / workspace allocation (they are sized from
++            # max_running_requests / the score-chunk bound, not the pool), so a
++            # clamp would just OOM later. Fail fast with an actionable message.
++            raise ValueError(
++                "R-KV decode aux memory (%.2f GiB rolling-query buffer + %.2f "
++                "GiB compaction workspace = %.2f GiB total) does not fit the "
++                "available KV budget (%.2f GiB). Lower --rkv-max-active-requests "
++                "or --rkv-window-size, raise --mem-fraction-static, or reduce the "
++                "model / context size."
++                % (
++                    rolling_bytes / (1 << 30),
++                    workspace_bytes / (1 << 30),
++                    aux_bytes / (1 << 30),
++                    available_bytes / (1 << 30),
++                )
 +            )
-+            reduced = min_keep
 +        logger.info(
 +            "R-KV decode: reserving %.2f GiB (%.2f GiB rolling-query buffer, "
 +            "%d rows x %d layers x window %d x %d heads x %d dim; + %.2f GiB "
@@ -928,7 +992,7 @@ index db4c8ad8e..10a3a688d 100644
      def _resolve_memory_pool_config(
          self: ModelRunner, pre_model_load_memory: int
      ) -> MemoryPoolConfig:
-@@ -1060,6 +1197,15 @@ class ModelRunnerKVCacheMixin:
+@@ -1060,6 +1204,15 @@ class ModelRunnerKVCacheMixin:
          page_size = self.server_args.page_size
  
          configurator = create_memory_pool_configurator(self)
@@ -945,7 +1009,7 @@ index db4c8ad8e..10a3a688d 100644
  
          # Apply external constraints (user cap, page alignment, PP sync)
 diff --git a/python/sglang/srt/server_args.py b/python/sglang/srt/server_args.py
-index c7162c16d..079621c32 100644
+index c7162c16d..71fe49ab5 100644
 --- a/python/sglang/srt/server_args.py
 +++ b/python/sglang/srt/server_args.py
 @@ -1848,6 +1848,77 @@ class ServerArgs:
@@ -1037,7 +1101,7 @@ index c7162c16d..079621c32 100644
          # Handle device-specific backends.
          self._handle_hpu_backends()
          self._handle_cpu_backends()
-@@ -2917,6 +2992,97 @@ class ServerArgs:
+@@ -2917,6 +2992,112 @@ class ServerArgs:
          self._apply_cuda_graph_compatibility()
          self._validate_cuda_graph_config()
  
@@ -1046,8 +1110,15 @@ index c7162c16d..079621c32 100644
 +
 +        See R-KV/doc/DESIGN.md: R-KV physically frees KV slots mid-generation,
 +        which is incompatible with prefix caching (the radix tree would keep
-+        references into freed slots), page_size > 1 (per-slot free), overlap
-+        scheduling (phase 1), and TP > 1 (per-rank eviction would diverge).
++        references into freed slots), page_size > 1 (per-slot free), and overlap
++        scheduling (phase 1).
++
++        Tensor parallelism (tp > 1) IS supported: each rank scores only its local
++        KV heads, so the per-token eviction score is all-reduced across the
++        attention-TP group before top-k (RKVCompressor._reduce_score_across_tp)
++        so every rank keeps the identical tokens. DP attention is NOT supported
++        (its padded / all-gathered forward_batch layout is untested against the
++        R-KV hooks).
 +
 +        Decode CUDA graph IS supported: a per-step hook
 +        (``RKVCompressor.begin_decode_step``) advances the compaction counters
@@ -1069,8 +1140,13 @@ index c7162c16d..079621c32 100644
 +            )
 +        if self.page_size not in (None, 1):
 +            raise ValueError("--enable-rkv requires --page-size 1 (per-slot free).")
-+        if self.tp_size > 1:
-+            raise ValueError("--enable-rkv does not support tensor parallelism yet.")
++        if self.enable_dp_attention:
++            raise ValueError(
++                "--enable-rkv supports tensor parallelism (tp>1) via a cross-rank "
++                "eviction-score all-reduce, but NOT --enable-dp-attention: its "
++                "padded / all-gathered forward_batch layout is untested against "
++                "R-KV's observe / override_decode_positions / maybe_compact hooks."
++            )
 +        if (
 +            self.rkv_max_active_requests is not None
 +            and self.rkv_max_active_requests <= 0
@@ -1127,9 +1203,12 @@ index c7162c16d..079621c32 100644
 +            raise ValueError(
 +                "--enable-rkv-prefill requires --page-size 1 (per-slot free)."
 +            )
-+        if self.tp_size > 1:
++        if self.enable_dp_attention:
 +            raise ValueError(
-+                "--enable-rkv-prefill does not support tensor parallelism yet."
++                "--enable-rkv-prefill supports tensor parallelism (tp>1) via a "
++                "cross-rank eviction-score all-reduce, but NOT "
++                "--enable-dp-attention (its padded / all-gathered forward_batch "
++                "layout is untested against the R-KV prefill hooks)."
 +            )
 +
      def _parse_cuda_graph_config(self):

--- a/SGLang/patch/rkv-sglang-0.5.14.patch
+++ b/SGLang/patch/rkv-sglang-0.5.14.patch
@@ -681,7 +681,7 @@ index 1cff5c983..071dd303b 100644
          self._linear_attn_registry_cache: Any = _UNSET
  
          # Load model weights and configure
-@@ -846,6 +854,99 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -846,6 +854,101 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                  host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
              )
  
@@ -706,6 +706,7 @@ index 1cff5c983..071dd303b 100644
 +                is_hybrid_swa=self.is_hybrid_swa,
 +                spec_enabled=not self.spec_algorithm.is_none(),
 +                page_size=sa.page_size,
++                kv_cache_dtype=self.kv_cache_dtype,
 +            )
 +            if _rkv_reason is not None:
 +                raise ValueError(_rkv_reason)
@@ -757,6 +758,7 @@ index 1cff5c983..071dd303b 100644
 +                is_hybrid_swa=self.is_hybrid_swa,
 +                spec_enabled=not self.spec_algorithm.is_none(),
 +                page_size=sa.page_size,
++                kv_cache_dtype=self.kv_cache_dtype,
 +            )
 +            if _rkv_reason is not None:
 +                raise ValueError(_rkv_reason)
@@ -781,7 +783,7 @@ index 1cff5c983..071dd303b 100644
          self.init_routed_experts_capturer()
          self.init_indexer_capturer()
  
-@@ -3001,10 +3102,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -3001,10 +3104,22 @@ class ModelRunner(ModelRunnerKVCacheMixin):
                  if self.device == "cpu"
                  else forward_batch.forward_mode.is_cuda_graph
              )
@@ -804,7 +806,7 @@ index 1cff5c983..071dd303b 100644
              )
  
              if (
-@@ -3072,6 +3185,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
+@@ -3072,6 +3187,25 @@ class ModelRunner(ModelRunnerKVCacheMixin):
              ):
                  forward_batch.post_forward_mlp_sync_batch(ret)
  

--- a/SGLang/rkv/algo.py
+++ b/SGLang/rkv/algo.py
@@ -17,6 +17,7 @@ R-KV supports grouped-query attention: ``q_heads`` may be a multiple of
 
 from __future__ import annotations
 
+import logging
 import math
 
 import torch
@@ -24,6 +25,30 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 __all__ = ["R1KV", "cal_similarity", "compute_attention_scores"]
+
+logger = logging.getLogger(__name__)
+
+# Lazily-loaded fused Triton redundancy kernel (CUDA-only). ``None`` = untried,
+# ``False`` = unavailable (no CUDA / no Triton), else the callable. Adopted per
+# R1KV instance via a one-time smoke check against the full-matrix reference.
+_FUSED_REDUNDANCY = None
+
+
+def _get_fused_redundancy():
+    global _FUSED_REDUNDANCY
+    if _FUSED_REDUNDANCY is None:
+        try:
+            if torch.cuda.is_available():
+                from sglang.srt.mem_cache.rkv.redundancy_fused import (
+                    cal_similarity_fused,
+                )
+
+                _FUSED_REDUNDANCY = cal_similarity_fused
+            else:
+                _FUSED_REDUNDANCY = False
+        except Exception:  # pragma: no cover - triton/build issue -> fallback
+            _FUSED_REDUNDANCY = False
+    return _FUSED_REDUNDANCY
 
 
 def compute_attention_scores(query_states, key_states, pooling="max"):
@@ -126,15 +151,48 @@ class R1KV:
         mix_lambda=0.07,
         retain_ratio=0.1,
         retain_direction="last",
+        fused_validation="first-request",
         **kwargs,
     ):
-        assert budget - window_size > 0, "budget must be greater than window_size"
+        if budget - window_size <= 0:
+            raise ValueError("R-KV budget must be greater than window_size")
         self.budget = budget
         self.window_size = window_size
         self.kernel_size = kernel_size
         self.mix_lambda = mix_lambda
         self.retain_ratio = retain_ratio
         self.retain_direction = retain_direction
+        # Fused redundancy backend: None=untried, False=reference fallback, else fn.
+        self._fused_redundancy = None
+        # Fused-kernel adoption policy: "off" (never use the fused kernel),
+        # "startup" (validate once with a synthetic tensor via
+        # warmup_fused_kernel, so the first real compaction pays no gate cost),
+        # or "first-request" (lazy — validate on the first real compaction).
+        self._fused_validation = fused_validation
+        if fused_validation == "off":
+            self._fused_redundancy = False
+
+    def warmup_fused_kernel(self, kv_heads, head_dim, device, dtype, seq_len=None):
+        """Startup validation of the fused redundancy kernel.
+
+        Runs the fused-vs-reference A/B gate once on a synthetic key tensor so
+        the first real compaction does not pay the gate cost, and a broken /
+        unavailable kernel is caught at startup instead of on a user's first
+        (possibly long) request. No-op unless ``fused_validation == "startup"``,
+        ``retain_direction == "last"``, and the device is CUDA; the adoption
+        decision it latches uses the real model's ``kv_heads`` / ``head_dim`` /
+        ``dtype``, which is what the kernel's correctness depends on.
+        """
+        if self._fused_validation != "startup":
+            return
+        dev = torch.device(device)
+        if self.retain_direction != "last" or dev.type != "cuda":
+            return
+        if self._fused_redundancy is not None:  # already decided (e.g. "off")
+            return
+        n = int(seq_len or max(self.budget, self.window_size + 1))
+        keys = torch.randn((1, kv_heads, n, head_dim), device=dev, dtype=dtype)
+        self._redundancy(keys)  # triggers the lazy gate, latches the decision
 
     def _scores(self, key_states, query_states):
         """Compute the per-past-token joint R-KV score.
@@ -161,16 +219,86 @@ class R1KV:
             stride=1,
         )
 
-        similarity_cos = cal_similarity(
-            key_states,
-            retain_ratio=self.retain_ratio,
-            retain_direction=self.retain_direction,
-        )[:, :, : -self.window_size]
+        similarity_cos = self._redundancy(key_states)[:, :, : -self.window_size]
 
         final_score = attn_cache * self.mix_lambda - similarity_cos * (
             1 - self.mix_lambda
         )
         return final_score
+
+    def _reference_redundancy(self, key_states):
+        # Reference redundancy for the fused-kernel smoke gate. On CUDA use the
+        # O(n)-memory tiled implementation: the full n x n matrix built by
+        # ``cal_similarity`` OOMs on long sequences (e.g. decode-mode compaction
+        # of a long prompt, where n = prompt length). ``cal_similarity_tiled`` is
+        # bit-parity with ``cal_similarity`` for ``retain_direction="last"``. On
+        # CPU (small test tensors, and no serving package on the import path) the
+        # full-matrix reference is fine.
+        if self.retain_direction == "last" and key_states.is_cuda:
+            from sglang.srt.mem_cache.rkv.prefill import cal_similarity_tiled
+
+            return cal_similarity_tiled(
+                key_states, threshold=0.5, retain_direction="last"
+            )
+        return cal_similarity(
+            key_states,
+            retain_ratio=self.retain_ratio,
+            retain_direction=self.retain_direction,
+        )
+
+    def _redundancy(self, key_states):
+        """Key-similarity redundancy per past token. On CUDA with
+        ``retain_direction='last'`` this uses the fused Triton kernel, adopted
+        once via a smoke gate against the full-matrix reference (a gross
+        mismatch -> permanent reference fallback, logged). On CPU, without
+        Triton, or for other retain directions it uses ``cal_similarity``.
+        """
+        if self.retain_direction != "last" or not key_states.is_cuda:
+            return self._reference_redundancy(key_states)
+        if self._fused_redundancy is False:
+            return self._reference_redundancy(key_states)
+        if self._fused_redundancy is not None:
+            # Guard the adopted kernel against SYNCHRONOUS failures (Triton
+            # compile / shape / launch errors, wrapper bugs): degrade to the
+            # reference permanently instead of crashing. Note the failure model:
+            # an ASYNCHRONOUS CUDA fault (illegal access / device-side assert)
+            # from the kernel does NOT surface here — it poisons the CUDA context
+            # and raises at a later sync point, which is (correctly) worker-fatal;
+            # we do not try to recover a poisoned context.
+            try:
+                return self._fused_redundancy(key_states, threshold=0.5)
+            except Exception as e:  # pragma: no cover - hardware/shape dependent
+                logger.warning(
+                    "R-KV decode fused-redundancy kernel failed at runtime (%s); "
+                    "falling back to the reference permanently.",
+                    e,
+                )
+                self._fused_redundancy = False
+                return self._reference_redundancy(key_states)
+        fn = _get_fused_redundancy()
+        if fn is False:
+            self._fused_redundancy = False
+            return self._reference_redundancy(key_states)
+        ref = self._reference_redundancy(key_states)
+        try:
+            got = fn(key_states, threshold=0.5)
+        except Exception as e:  # pragma: no cover - hardware/shape dependent
+            logger.warning(
+                "R-KV decode fused-redundancy kernel unavailable at runtime (%s); "
+                "using the reference permanently.",
+                e,
+            )
+            self._fused_redundancy = False
+            return ref
+        ok = ref.shape == got.shape and torch.allclose(
+            ref.float(), got.float(), atol=1e-3, rtol=1e-2
+        )
+        self._fused_redundancy = fn if ok else False
+        logger.info(
+            "R-KV decode fused-redundancy gate: %s",
+            "OK -> fused adopted" if ok else "DIVERGED -> reference fallback",
+        )
+        return got if ok else ref
 
     def select_indices(self, key_states, query_states, sort=True):
         """Return the token indices to keep, per (batch, kv head).
@@ -197,11 +325,15 @@ class R1KV:
         past_indices = final_score.topk(self.budget - self.window_size, dim=-1).indices
 
         bsz, kv_heads = past_indices.shape[0], past_indices.shape[1]
-        window_indices = torch.arange(
-            kv_cache_len - self.window_size,
-            kv_cache_len,
-            device=past_indices.device,
-        ).view(1, 1, -1).expand(bsz, kv_heads, -1)
+        window_indices = (
+            torch.arange(
+                kv_cache_len - self.window_size,
+                kv_cache_len,
+                device=past_indices.device,
+            )
+            .view(1, 1, -1)
+            .expand(bsz, kv_heads, -1)
+        )
 
         kept = torch.cat([past_indices, window_indices], dim=-1)
         if sort:

--- a/SGLang/rkv/integration.py
+++ b/SGLang/rkv/integration.py
@@ -69,6 +69,18 @@ RKV_SCORE_CHUNK_BYTES: int = 512 << 20
 # every layer's KV buffer with full ``req_to_token`` slots.
 _RKV_SUPPORTED_ATTENTION_BACKENDS = ("flashinfer",)
 
+# KV-cache dtypes R-KV scoring can consume directly. The compressor reads the
+# raw K/V buffer (``token_to_kv_pool.get_key_buffer``) and feeds it straight into
+# RMSNorm / ``q @ k^T`` importance+redundancy scoring with NO dequantization
+# path, so a quantized KV cache (fp8/fp4) would be scored in the wrong numeric
+# representation. Restrict to unquantized float KV until scoring learns to apply
+# the per-layer ``k_scale``/``v_scale`` dequant.
+_RKV_SUPPORTED_KV_CACHE_DTYPES = (
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+)
+
 
 def rkv_runtime_support_error(
     *,
@@ -79,6 +91,7 @@ def rkv_runtime_support_error(
     is_hybrid_swa: bool,
     spec_enabled: bool,
     page_size: Optional[int],
+    kv_cache_dtype: Optional[torch.dtype] = None,
 ) -> Optional[str]:
     """Return a reason the *resolved* runtime cannot support R-KV, else ``None``.
 
@@ -97,8 +110,13 @@ def rkv_runtime_support_error(
     * speculative decoding (e.g. TARGET_VERIFY) drives extra forwards the hooks
       do not account for;
     * page_size must be 1 for per-slot free.
+    * quantized KV-cache dtypes (fp8_e4m3 / fp8_e5m2 / fp4_e2m1) cannot be
+      scored: the compressor reads the raw K/V buffer and feeds it into RMSNorm
+      / ``q @ k^T`` with no ``k_scale``/``v_scale`` dequantization path.
 
     ``mode`` is ``"decode"`` or ``"prefill"`` (used only in the message).
+    ``kv_cache_dtype`` is the *resolved* KV-cache ``torch.dtype`` (from
+    ``ModelRunner.configure_kv_cache_dtype``); ``None`` skips the dtype check.
     """
     if (
         prefill_backend not in _RKV_SUPPORTED_ATTENTION_BACKENDS
@@ -131,6 +149,18 @@ def rkv_runtime_support_error(
         )
     if page_size not in (None, 1):
         return f"R-KV ({mode}) requires page_size == 1 (per-slot free)."
+    if (
+        kv_cache_dtype is not None
+        and kv_cache_dtype not in _RKV_SUPPORTED_KV_CACHE_DTYPES
+    ):
+        return (
+            f"R-KV ({mode}) does not support a quantized KV cache dtype "
+            f"({kv_cache_dtype}): the compressor reads the raw K/V buffer and "
+            "scores it with RMSNorm / q @ k^T with no dequantization path, so "
+            "fp8_e4m3 / fp8_e5m2 / fp4_e2m1 would be ranked in the wrong "
+            "representation. Use an unquantized KV cache (fp16/bf16/fp32) until "
+            "R-KV scoring learns to dequantize (k_scale/v_scale)."
+        )
     return None
 
 

--- a/SGLang/rkv/integration.py
+++ b/SGLang/rkv/integration.py
@@ -37,8 +37,9 @@ the bottom and the roadmap in ``R-KV/doc/DESIGN.md`` section 9.
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import msgspec
 import torch
@@ -61,6 +62,76 @@ logger = logging.getLogger(__name__)
 # KV-pool sizing reserves so a compaction never OOMs on transient tensors even
 # when the pool is full (ModelRunner._reserve_rkv_decode_aux_bytes).
 RKV_SCORE_CHUNK_BYTES: int = 512 << 20
+
+
+# Backends into which the R-KV observation / compaction hooks are actually
+# wired. The hooks live only in the MHA FlashInfer attention backend and index
+# every layer's KV buffer with full ``req_to_token`` slots.
+_RKV_SUPPORTED_ATTENTION_BACKENDS = ("flashinfer",)
+
+
+def rkv_runtime_support_error(
+    *,
+    mode: str,
+    prefill_backend: Optional[str],
+    decode_backend: Optional[str],
+    use_mla: bool,
+    is_hybrid_swa: bool,
+    spec_enabled: bool,
+    page_size: Optional[int],
+) -> Optional[str]:
+    """Return a reason the *resolved* runtime cannot support R-KV, else ``None``.
+
+    ``ServerArgs._handle_rkv*_validation`` runs before the attention backend,
+    model architecture, page size, and speculative algorithm are resolved, so it
+    cannot see what is actually wired. This pure check is called from
+    ``ModelRunner`` right before the compressor is built, once everything is
+    resolved, and hard-fails any configuration whose runtime the observation /
+    compaction hooks do not cover:
+
+    * the hooks exist ONLY in the MHA FlashInfer backend (prefill observe lives
+      in ``forward_extend``; decode observe in ``forward_decode``);
+    * they index every layer buffer with full ``req_to_token`` slots, so MLA
+      (different KV layout) and hybrid-SWA (needs full->SWA slot translation)
+      pools are unsupported;
+    * speculative decoding (e.g. TARGET_VERIFY) drives extra forwards the hooks
+      do not account for;
+    * page_size must be 1 for per-slot free.
+
+    ``mode`` is ``"decode"`` or ``"prefill"`` (used only in the message).
+    """
+    if (
+        prefill_backend not in _RKV_SUPPORTED_ATTENTION_BACKENDS
+        or decode_backend not in _RKV_SUPPORTED_ATTENTION_BACKENDS
+    ):
+        return (
+            f"R-KV ({mode}) requires the FlashInfer attention backend for both "
+            f"prefill and decode (resolved prefill={prefill_backend!r}, "
+            f"decode={decode_backend!r}); the R-KV observation hooks are wired "
+            "only into FlashInferAttnBackend."
+        )
+    if use_mla:
+        return (
+            f"R-KV ({mode}) does not support MLA models: the compressor indexes "
+            "every layer's KV buffer with full req_to_token slots, which the MLA "
+            "pool layout does not provide."
+        )
+    if is_hybrid_swa:
+        return (
+            f"R-KV ({mode}) does not support hybrid sliding-window (SWA) models: "
+            "SWA layers require full-to-SWA slot translation that the compressor "
+            "does not perform (it indexes every layer with full req_to_token "
+            "slots)."
+        )
+    if spec_enabled:
+        return (
+            f"R-KV ({mode}) does not support speculative decoding: TARGET_VERIFY "
+            "and draft forwards are not wired into the observation/compaction "
+            "hooks."
+        )
+    if page_size not in (None, 1):
+        return f"R-KV ({mode}) requires page_size == 1 (per-slot free)."
+    return None
 
 
 class _CompactionCommit(msgspec.Struct):
@@ -112,6 +183,25 @@ class RKVConfig:
             self.min_seq_len = self.budget
         # Config validation raises (not assert, which -O strips) so an invalid
         # --rkv-config can never silently start a corrupting server.
+        if self.window_size <= 0:
+            raise ValueError("R-KV window_size must be a positive integer")
+        if self.kernel_size <= 0 or self.kernel_size % 2 == 0:
+            raise ValueError(
+                "R-KV kernel_size must be a positive ODD integer: max_pool1d "
+                "with an even kernel emits n-window+1 importance values against "
+                "n-window redundancy values, which fails deterministically in "
+                "R1KV._scores"
+            )
+        if self.retain_direction not in (
+            "last",
+            "first",
+            "last_percent",
+            "first_percent",
+        ):
+            raise ValueError(
+                "R-KV retain_direction must be one of 'last' / 'first' / "
+                "'last_percent' / 'first_percent'"
+            )
         if self.budget <= self.window_size:
             raise ValueError("R-KV budget must exceed window_size")
         if self.buffer_size < self.window_size:
@@ -184,8 +274,24 @@ class RKVCompressor:
         head_dim: int,
         q_dtype: torch.dtype,
         fused_validation: str = "first-request",
+        attn_tp_group=None,
     ) -> None:
         self.config = config
+        # Serving is restricted to the memory-BOUNDED redundancy path. Only
+        # retain_direction="last" uses the fused Triton kernel / O(n)-memory
+        # tiled reference; every other direction falls back to cal_similarity,
+        # which materializes a kv_heads x n x n cosine matrix (+ mask + int64
+        # indices) that can reach many GiB and is NOT covered by the fixed
+        # compaction-workspace reservation. Reject it here rather than OOM mid
+        # serving. (The algorithm still supports other directions for offline
+        # use; only the served RKVCompressor is gated.)
+        if config.retain_direction != "last":
+            raise ValueError(
+                "R-KV serving supports only retain_direction='last' (the "
+                f"memory-bounded path); got {config.retain_direction!r}. Other "
+                "directions build an unbounded kv_heads x n x n similarity "
+                "matrix that the compaction-workspace reservation cannot cap."
+            )
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool = token_to_kv_pool
         self.kv_allocator = kv_allocator
@@ -193,6 +299,22 @@ class RKVCompressor:
         self.end_layer = end_layer
         self.num_layers = end_layer - start_layer
         self.device = device
+
+        # Attention-TP group. Under TP each rank holds only a SUBSET of the KV
+        # heads, so its per-token score (a cross-head mean over LOCAL heads)
+        # differs from other ranks -> different kept set -> the replicated
+        # req_to_token diverges -> silent KV corruption. We sum the per-token
+        # score across this group before top-k so every rank keeps the exact
+        # same tokens (see _reduce_score_across_tp). ``None`` / world_size==1
+        # means no TP: the reduce and check are no-ops (single-GPU unchanged).
+        self.attn_tp_group = attn_tp_group
+        self.attn_tp_size = (
+            getattr(attn_tp_group, "world_size", 1) if attn_tp_group is not None else 1
+        )
+        # TP kept-set consistency check: self-validate on the first few
+        # compactions (cheap), or every compaction when SGLANG_RKV_TP_CHECK=1.
+        self._tp_check_always = os.environ.get("SGLANG_RKV_TP_CHECK", "0") == "1"
+        self._tp_check_remaining = 8
 
         self.algo = R1KV(
             budget=config.budget,
@@ -224,10 +346,14 @@ class RKVCompressor:
         # (``commit_compactions``) to free slots + finalize bookkeeping, keeping
         # allocator mutation out of the forward stream.
         self._pending_commits: List[_CompactionCommit] = []
-        # req_pool_idx -> new physical KV length after the latest compaction.
-        # The scheduler drains this (``take_pending_length_updates``) to update
-        # the batch-level seq_lens tensors, which it owns.
-        self.pending_length_updates: Dict[int, int] = {}
+        # req_pool_idx -> (new physical KV length, owning Req) after the latest
+        # compaction. The scheduler drains this (``take_pending_length_updates``)
+        # to update the batch-level seq_lens tensors, which it owns. The owning
+        # Req is stored so the scheduler can VALIDATE identity before applying an
+        # update: if the pool slot was released and reused between the compaction
+        # and the drain, the update belongs to a dead request and must be
+        # ignored (belt-and-braces with the clear-on-finish/retract below).
+        self.pending_length_updates: Dict[int, Tuple[int, Req]] = {}
         # Batched-scoring A/B gate: None = not yet checked, True = batched
         # selects the same kept set as the per-layer reference (adopted), False
         # = they differed on the first compaction (per-layer fallback forever).
@@ -297,9 +423,36 @@ class RKVCompressor:
         # observation window (does not inherit the previous request's cursor).
         self.step_count_of_req[req.req_pool_idx] = 0
 
+    def _clear_request_state(self, idx: int) -> bool:
+        """Drop ALL per-request R-KV bookkeeping for ``idx`` and return whether a
+        state existed.
+
+        Every finish/retract path routes through here so no stale compaction
+        artifact (pending physical-length update or armed flag) can survive the
+        release of ``idx`` and be applied to the next request that reuses the
+        same pool slot. ``_pending_commits`` is intentionally NOT touched: the
+        scheduler always drains it (``commit_compactions``) BEFORE the finish
+        loop that calls ``on_request_end``, so a queued commit is never left
+        behind; if one somehow is, the commit-path stale-plan identity guard in
+        ``_commit_compaction`` must still fire rather than be silently dropped.
+        """
+        had = self.states.pop(idx, None) is not None
+        self.pending_length_updates.pop(idx, None)
+        self._armed.discard(idx)
+        return had
+
     def on_request_end(self, req: Req) -> None:
-        """Drop a request's R-KV state when it finishes or aborts."""
-        if req.req_pool_idx is not None and self.states.pop(req.req_pool_idx, None):
+        """Drop a request's R-KV state (and any pending compaction bookkeeping)
+        when it finishes or aborts.
+
+        Clearing the pending length update / armed flag / queued commit is
+        REQUIRED, not just tidy: a request can compact and finish on the same
+        step (or finish as the last request in the batch), after which the pool
+        slot is released and reused. A leftover ``pending_length_updates`` entry
+        would then be applied to whatever request next reuses this
+        ``req_pool_idx`` in ``_apply_rkv_pre_decode``, corrupting its seq_lens.
+        """
+        if req.req_pool_idx is not None and self._clear_request_state(req.req_pool_idx):
             logger.debug(
                 "R-KV on_request_end req_pool_idx=%d states_left=%d",
                 req.req_pool_idx,
@@ -317,7 +470,7 @@ class RKVCompressor:
         while ``req.req_pool_idx`` is still valid, i.e. BEFORE the pool frees it.
         """
         if req.req_pool_idx is not None:
-            self.states.pop(req.req_pool_idx, None)
+            self._clear_request_state(req.req_pool_idx)
 
     # ------------------------------------------------------------------
     # Scheduler admission support
@@ -585,7 +738,11 @@ class RKVCompressor:
         self._armed = set()
 
         seq_len_by_req = self._seq_len_by_req(forward_batch)
-        for req_pool_idx in list(armed):
+        # sorted() (not list(set)) so every attention-TP rank iterates the armed
+        # requests in the SAME order and therefore issues the per-request score
+        # all-reduces in the same order — mismatched collective order across
+        # ranks would pair the wrong tensors (silent corruption / hang).
+        for req_pool_idx in sorted(armed):
             # An armed request was armed from THIS forward's req_pool_indices in
             # begin_decode_step, and no lifecycle hook runs between arming and
             # here (same forward). So a missing state or seq_len is a genuine
@@ -612,10 +769,14 @@ class RKVCompressor:
 
             if self._batched_ok is None:
                 ref_kept = self._assemble_kept(
-                    self._reference_scores(state, seq_len), seq_len
+                    self._reduce_score_across_tp(
+                        self._reference_scores(state, seq_len)
+                    ),
+                    seq_len,
                 )
                 bat_kept = self._assemble_kept(
-                    self._batched_scores(state, seq_len), seq_len
+                    self._reduce_score_across_tp(self._batched_scores(state, seq_len)),
+                    seq_len,
                 )
                 same_shape = ref_kept.shape == bat_kept.shape
                 self._batched_ok = bool(same_shape and torch.equal(ref_kept, bat_kept))
@@ -630,13 +791,16 @@ class RKVCompressor:
                 )
                 kept = bat_kept if self._batched_ok else ref_kept
             else:
-                score = (
+                score = self._reduce_score_across_tp(
                     self._batched_scores(state, seq_len)
                     if self._batched_ok
                     else self._reference_scores(state, seq_len)
                 )
                 kept = self._assemble_kept(score, seq_len)
 
+            # Under TP, verify every rank derived the identical kept set (turns a
+            # silent cross-rank KV divergence into a loud failure).
+            self._check_kept_consistent_across_tp(kept)
             self._pending_commits.append(self._prepare_compaction(state, seq_len, kept))
 
     def commit_compactions(self) -> None:
@@ -656,6 +820,55 @@ class RKVCompressor:
         self._pending_commits = []
         for plan in plans:
             self._commit_compaction(plan)
+
+    # ------------------------------------------------------------------
+    # Tensor-parallel score agreement
+    # ------------------------------------------------------------------
+    def _reduce_score_across_tp(self, score: torch.Tensor) -> torch.Tensor:
+        """Sum the per-token eviction score across the attention-TP group.
+
+        R-KV's score is a cross-head MEAN, computed here over each rank's LOCAL
+        kv heads only; the softmax/pool inside the score are per-head, so the
+        cross-head reduction is LINEAR. Head sharding is uniform (either
+        ``num_kv_heads % tp == 0`` for distinct heads, or ``tp % num_kv_heads ==
+        0`` with uniform replication), so the all-reduced SUM equals the true
+        global cross-head mean scaled by a positive constant. ``topk`` is
+        invariant to positive scaling, so after this every rank selects the
+        IDENTICAL kept set — which is what keeps the replicated ``req_to_token``
+        consistent across ranks. No-op at tp==1 (single-GPU path unchanged).
+        """
+        if self.attn_tp_group is None or self.attn_tp_size <= 1:
+            return score
+        # fp32 all-reduce: identical across ranks (all-reduce semantics), and
+        # bounded-magnitude so ``topk`` ties break identically on every rank.
+        return self.attn_tp_group.all_reduce(score.float())
+
+    def _check_kept_consistent_across_tp(self, kept: torch.Tensor) -> None:
+        """Assert every attention-TP rank derived the identical kept set.
+
+        Turns a silent cross-rank KV divergence (the failure mode that makes TP
+        unsafe without the score all-reduce) into a loud error. Runs on the
+        first few compactions (cheap startup self-validation) or on every
+        compaction when ``SGLANG_RKV_TP_CHECK=1``. The fire schedule is a
+        function of the (rank-identical) compaction count, so the extra
+        collective is issued in lockstep across ranks.
+        """
+        if self.attn_tp_group is None or self.attn_tp_size <= 1:
+            return
+        if not self._tp_check_always:
+            if self._tp_check_remaining <= 0:
+                return
+            self._tp_check_remaining -= 1
+        # kept indices are < seq_len (<= a few 10k) and tp <= a handful, so the
+        # summed values stay exactly representable in fp32.
+        local = kept.to(torch.float32)
+        summed = self.attn_tp_group.all_reduce(local.clone())
+        if not torch.equal(summed, local * self.attn_tp_size):
+            raise RuntimeError(
+                "R-KV TP divergence: attention-TP ranks selected different kept "
+                "sets. The per-token score all-reduce is not producing identical "
+                "scores across ranks; continuing would corrupt the KV cache."
+            )
 
     def _assemble_kept(self, score_accum: torch.Tensor, seq_len: int) -> torch.Tensor:
         """Global kept-token indices: top past tokens + trailing window.
@@ -800,7 +1013,7 @@ class RKVCompressor:
         if plan.req is not None:
             plan.req.kv_committed_len = budget
             plan.req.kv_allocated_len = budget
-        self.pending_length_updates[idx] = budget
+        self.pending_length_updates[idx] = (budget, plan.req)
 
         logger.info(
             "R-KV compacted req_pool_idx=%d: phys %d -> %d slots (freed %d)",
@@ -839,13 +1052,14 @@ class RKVCompressor:
         """
         return len(req.origin_input_ids) + len(req.output_ids)
 
-    def take_pending_length_updates(self) -> Dict[int, int]:
-        """Return and clear the pending {req_pool_idx: new_physical_len} map.
+    def take_pending_length_updates(self) -> Dict[int, Tuple[int, Req]]:
+        """Return and clear the pending {req_pool_idx: (new_physical_len, req)} map.
 
         The scheduler calls this right after the forward pass to apply the new
         physical lengths to its batch-level seq_lens / seq_lens_cpu tensors
         (the request-level kv_committed_len / kv_allocated_len are already
-        updated in-place during compaction).
+        updated in-place during compaction). The owning Req is returned so the
+        scheduler can drop an update whose slot was reused (identity mismatch).
         """
         updates = self.pending_length_updates
         self.pending_length_updates = {}

--- a/SGLang/rkv/integration.py
+++ b/SGLang/rkv/integration.py
@@ -9,7 +9,7 @@ Scope of this module (phase 1, correctness first):
 
 * FlashInfer backend, ``batch >= 1`` with **per-request triggering**: each
   request independently decides when to compress based on its own KV length
-  (see :meth:`RKVCompressor.observe_decode_layer`).
+  (see :meth:`RKVCompressor.begin_decode_step`).
 * ``page_size == 1`` token pool, so evicted slots free cleanly one-by-one
   (the paged allocator frees at page granularity; see R-KV/doc/DESIGN.md
   section 8).
@@ -38,8 +38,9 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+import msgspec
 import torch
 
 from sglang.srt.mem_cache.rkv.algo import R1KV
@@ -52,6 +53,33 @@ if TYPE_CHECKING:  # pragma: no cover - typing only, avoids heavy imports
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 logger = logging.getLogger(__name__)
+
+
+# Cap on the batched-scoring transient (cosine matrix + mask + indices) per
+# compaction. Because compactions run sequentially (one armed request at a time
+# in ``maybe_compact``), this is also the per-step compaction-workspace peak the
+# KV-pool sizing reserves so a compaction never OOMs on transient tensors even
+# when the pool is full (ModelRunner._reserve_rkv_decode_aux_bytes).
+RKV_SCORE_CHUNK_BYTES: int = 512 << 20
+
+
+class _CompactionCommit(msgspec.Struct):
+    """One prepared compaction awaiting the scheduler-synced commit.
+
+    Emitted by the forward-side *prepare* phase (``_prepare_compaction``), after
+    the surviving K/V has already been relocated to the front ``budget`` slots.
+    The scheduler drains these after the forward (``commit_compactions``) to free
+    the tail slots and finalize the request bookkeeping, so the allocator is
+    mutated only at a point where the forward stream is synced — not from inside
+    the forward. ``freed_slots`` is a device tensor and ``req`` a duck-typed
+    ``Req``; this struct is an in-process container only (never serialized).
+    """
+
+    req_pool_idx: int
+    budget: int
+    seq_len: int
+    freed_slots: Any
+    req: Any
 
 
 @dataclass
@@ -82,14 +110,20 @@ class RKVConfig:
     def __post_init__(self) -> None:
         if self.min_seq_len is None:
             self.min_seq_len = self.budget
-        assert self.budget > self.window_size, "budget must exceed window_size"
-        assert self.buffer_size >= self.window_size, (
-            "buffer_size must be >= window_size, otherwise the first compaction "
-            "scores against zero-initialized queries in the observation window"
-        )
-        assert self.min_seq_len >= self.budget, (
-            "min_seq_len must be >= budget (select_indices keeps budget tokens)"
-        )
+        # Config validation raises (not assert, which -O strips) so an invalid
+        # --rkv-config can never silently start a corrupting server.
+        if self.budget <= self.window_size:
+            raise ValueError("R-KV budget must exceed window_size")
+        if self.buffer_size < self.window_size:
+            raise ValueError(
+                "R-KV buffer_size must be >= window_size, otherwise the first "
+                "compaction scores against zero-initialized observation queries"
+            )
+        if self.min_seq_len < self.budget:
+            raise ValueError(
+                "R-KV min_seq_len must be >= budget (select_indices keeps budget "
+                "tokens)"
+            )
 
 
 class RKVRequestState:
@@ -102,84 +136,31 @@ class RKVRequestState:
     compaction step.
     """
 
-    def __init__(
-        self,
-        req_pool_idx: int,
-        num_layers: int,
-        window_size: int,
-        device: torch.device,
-        dtype: torch.dtype,
-    ) -> None:
+    def __init__(self, req_pool_idx: int) -> None:
         self.req_pool_idx = req_pool_idx
-        self.num_layers = num_layers
-        self.window_size = window_size
-        self.device = device
-        self.dtype = dtype
 
-        # Generated steps since the last compaction (trigger cadence counter).
+        # Generated steps since the last compaction (trigger cadence counter),
+        # advanced once per decode step by ``RKVCompressor.begin_decode_step``
+        # (which runs every step, unlike the in-graph query collection which is
+        # captured once into the decode graph and replayed).
         self.steps_since_compact = 0
 
-        # Logical absolute position of the request's next token. Decoupled from
-        # the physical KV length so that rotary positions stay continuous after
-        # tokens are dropped. Set to the prompt length in ``on_request_begin``.
+        # Logical absolute position of the request's next token (vestigial:
+        # decode positions are derived from the request in
+        # ``override_decode_positions``, not from this field).
         self.next_position = 0
 
-        # Per-layer ring buffer of the most recent ``window_size`` decode
-        # queries: (num_layers, window_size, q_head_num, head_dim). Allocated
-        # lazily on the first ``push_query`` once the query shape is known.
-        self.query_window: Optional[torch.Tensor] = None
-        # Number of valid queries currently in the window (<= window_size).
-        self.query_filled = 0
-        # Write cursor into the ring buffer; advanced once per decode *step*
-        # (shared by all layers within that step).
-        self._write_pos = 0
-
-        # Transient cross-layer per-token score accumulator, allocated lazily at
-        # the start of a compaction step and cleared afterwards.
-        self.score_accum: Optional[torch.Tensor] = None
+        # Per-layer observation-window queries, shape
+        # (num_layers, window_size, q_head_num, head_dim), set transiently in
+        # ``maybe_compact`` from the in-graph ``rolling_q`` collection (read
+        # un-rotated to temporal order) right before scoring this request.
+        self.window_q: Optional[torch.Tensor] = None
 
         # Back-reference to the owning request, so compaction can update its
         # physical-length bookkeeping (kv_committed_len / kv_allocated_len).
         # Duck-typed: only needs kv_committed_len / kv_allocated_len /
         # origin_input_ids / output_ids. Set in ``on_request_begin``.
-        self.req: Optional["Req"] = None
-
-    def begin_step(self) -> None:
-        """Advance the ring cursor at the start of a new decode step."""
-        self._write_pos = (self._write_pos + 1) % self.window_size
-        self.query_filled = min(self.query_filled + 1, self.window_size)
-        self.steps_since_compact += 1
-        self.next_position += 1
-
-    def push_query(self, layer_idx: int, q: torch.Tensor) -> None:
-        """Store this step's query for ``layer_idx``.
-
-        ``q`` is ``(q_head_num, head_dim)`` (batch=1, single decode token). The
-        per-layer ring buffer is allocated on first use from ``q``'s shape.
-        """
-        if self.query_window is None:
-            q_head_num, head_dim = q.shape[-2], q.shape[-1]
-            self.query_window = torch.zeros(
-                (self.num_layers, self.window_size, q_head_num, head_dim),
-                device=self.device,
-                dtype=q.dtype,
-            )
-        self.query_window[layer_idx, self._write_pos].copy_(q)
-
-    def ordered_window(self, layer_idx: int) -> torch.Tensor:
-        """Return the window queries for a layer in temporal order.
-
-        Shape ``(window_size, q_head_num, head_dim)``; oldest first, newest
-        last, matching what :meth:`R1KV._scores` expects for the observation
-        window.
-        """
-        # Roll the ring so the oldest valid entry comes first.
-        order = (
-            torch.arange(self.window_size, device=self.query_window.device)
-            + self._write_pos
-            + 1
-        ) % self.window_size
-        return self.query_window[layer_idx].index_select(0, order)
+        self.req: Optional[Req] = None
 
 
 class RKVCompressor:
@@ -193,12 +174,16 @@ class RKVCompressor:
     def __init__(
         self,
         config: RKVConfig,
-        req_to_token_pool: "ReqToTokenPool",
-        token_to_kv_pool: "KVCache",
-        kv_allocator: "BaseTokenToKVPoolAllocator",
+        req_to_token_pool: ReqToTokenPool,
+        token_to_kv_pool: KVCache,
+        kv_allocator: BaseTokenToKVPoolAllocator,
         start_layer: int,
         end_layer: int,
         device: torch.device,
+        q_head_num: int,
+        head_dim: int,
+        q_dtype: torch.dtype,
+        fused_validation: str = "first-request",
     ) -> None:
         self.config = config
         self.req_to_token_pool = req_to_token_pool
@@ -216,37 +201,103 @@ class RKVCompressor:
             mix_lambda=config.mix_lambda,
             retain_ratio=config.retain_ratio,
             retain_direction=config.retain_direction,
+            fused_validation=fused_validation,
+        )
+        # Startup fused-kernel validation (no-op unless fused_validation ==
+        # "startup"): warm the fused-vs-reference gate now, using the real KV
+        # head count / dtype, so the first real compaction pays no gate cost.
+        k0 = self.token_to_kv_pool.get_key_buffer(self.start_layer)
+        self.algo.warmup_fused_kernel(
+            kv_heads=k0.shape[1],
+            head_dim=head_dim,
+            device=device,
+            dtype=k0.dtype,
+            seq_len=config.budget,
         )
 
         # Active per-request state, keyed by req_pool_idx.
         self.states: Dict[int, RKVRequestState] = {}
         # req_pool_idx values that armed a compaction this forward pass.
         self._armed: set[int] = set()
+        # Two-phase compaction: the forward-side prepare phase relocates K/V and
+        # appends a commit record here; the scheduler drains it after the forward
+        # (``commit_compactions``) to free slots + finalize bookkeeping, keeping
+        # allocator mutation out of the forward stream.
+        self._pending_commits: List[_CompactionCommit] = []
         # req_pool_idx -> new physical KV length after the latest compaction.
         # The scheduler drains this (``take_pending_length_updates``) to update
         # the batch-level seq_lens tensors, which it owns.
         self.pending_length_updates: Dict[int, int] = {}
+        # Batched-scoring A/B gate: None = not yet checked, True = batched
+        # selects the same kept set as the per-layer reference (adopted), False
+        # = they differed on the first compaction (per-layer fallback forever).
+        self._batched_ok: Optional[bool] = None
+        # Cap the batched-scoring transient (cosine matrix + mask + indices) so
+        # peak memory stays bounded when budget (=> seq_len) is large. This is
+        # also the per-request compaction-workspace bound the KV-pool sizing
+        # reserves (ModelRunner._reserve_rkv_decode_aux_bytes).
+        self._score_chunk_bytes: int = RKV_SCORE_CHUNK_BYTES
+
+        # --- (1c) in-graph decode query collection ---
+        # Rolling per-layer observation-window buffer, keyed by req_pool_idx (so
+        # it survives batch reordering). It is written INSIDE the decode CUDA
+        # graph via an index_copy_ scatter in forward_decode -- the same class of
+        # op as set_kv_buffer writing token_to_kv_pool at out_cache_loc -- so the
+        # observation-window steps no longer need to run eager. Circular over
+        # window_size; the write slot is a global (batch-synchronous) counter.
+        #
+        # Row count == req_to_token rows == max_running_requests + 1, so there is
+        # exactly one row per possible concurrent request (no oversized pool: the
+        # decode concurrency ceiling IS the row count). Row 0 is the reserved
+        # ReqToTokenPool padding slot (never assigned to a real request), which is
+        # what makes the unconditional in-graph scatter safe under CUDA-graph
+        # padding -- see collect_decode_query. This buffer is reserved in the KV
+        # pool sizing (ModelRunner._reserve_rkv_decode_aux_bytes) so it cannot OOM
+        # at startup.
+        max_reqs = req_to_token_pool.req_to_token.shape[0]
+        window = config.window_size
+        self.rolling_q = torch.zeros(
+            (self.num_layers, window, max_reqs, q_head_num, head_dim),
+            device=device,
+            dtype=q_dtype,
+        )
+        # Flattened (window * max_reqs) view for the in-graph scatter index.
+        self._rolling_q_flat = self.rolling_q.view(
+            self.num_layers, window * max_reqs, q_head_num, head_dim
+        )
+        self._rolling_max_reqs = max_reqs
+        # Per-request decode-step counter, keyed by req_pool_idx (a fixed-address
+        # GPU tensor). This step's circular write slot for request ``r`` is
+        # ``step_count_of_req[r] % window_size``. begin_decode_step advances it
+        # for every request in the batch each decode step (incl. graph-replay
+        # steps), and collect_decode_query reads it in-graph. Per-request (not a
+        # single global cursor) so the observation window stays correct even if a
+        # request skips decode steps (future preemption/pipeline/overlap): each
+        # request's slots only advance on the steps it actually participates in.
+        # Padding safety does NOT depend on row 0's counter value: row 0 is the
+        # reserved ReqToTokenPool padding slot (never a real request), so any
+        # padding-row write lands on rolling_q row 0 harmlessly regardless of the
+        # counter — the same reason the in-graph scatter is safe under padding.
+        self.step_count_of_req = torch.zeros(
+            (max_reqs,), device=device, dtype=torch.long
+        )
 
     # ------------------------------------------------------------------
     # Request lifecycle
     # ------------------------------------------------------------------
-    def on_request_begin(self, req: "Req") -> None:
+    def on_request_begin(self, req: Req) -> None:
         """Register a request and initialise its R-KV state."""
         if req.req_pool_idx is None:
             return
-        dtype = self.token_to_kv_pool.get_key_buffer(self.start_layer).dtype
-        state = RKVRequestState(
-            req_pool_idx=req.req_pool_idx,
-            num_layers=self.num_layers,
-            window_size=self.config.window_size,
-            device=self.device,
-            dtype=dtype,
-        )
+        state = RKVRequestState(req_pool_idx=req.req_pool_idx)
         state.next_position = len(req.origin_input_ids)
         state.req = req
         self.states[req.req_pool_idx] = state
+        # Reset this slot's step counter so a reused req_pool_idx starts a fresh
+        # observation window (does not inherit the previous request's cursor).
+        self.step_count_of_req[req.req_pool_idx] = 0
 
-    def on_request_end(self, req: "Req") -> None:
+    def on_request_end(self, req: Req) -> None:
         """Drop a request's R-KV state when it finishes or aborts."""
         if req.req_pool_idx is not None and self.states.pop(req.req_pool_idx, None):
             logger.debug(
@@ -255,74 +306,162 @@ class RKVCompressor:
                 len(self.states),
             )
 
+    def on_request_retract(self, req: Req) -> None:
+        """Discard a retracted request's R-KV state.
+
+        Retraction frees the request's physical KV and sends it back to the
+        waiting queue to be re-prefilled from scratch. Its old state (compaction
+        counter, observation-window queries, physical-length bookkeeping) no
+        longer matches the freed KV, so drop it here; a clean state is rebuilt by
+        ``on_request_begin`` when the request re-enters decode. Must be called
+        while ``req.req_pool_idx`` is still valid, i.e. BEFORE the pool frees it.
+        """
+        if req.req_pool_idx is not None:
+            self.states.pop(req.req_pool_idx, None)
+
+    # ------------------------------------------------------------------
+    # Scheduler admission support
+    # ------------------------------------------------------------------
+    def admission_reserve(self, prompt_len: int, occupied: int) -> int:
+        """Upper bound on the *future* physical KV a request can still consume.
+
+        R-KV holds a request's physical KV cache at a constant ceiling no matter
+        how many tokens it will still generate: it lets the length grow to at
+        most ``max(prompt_len, min_seq_len) + buffer_size`` (the peak reached the
+        step just before a compaction) and then frees back down to ``budget``.
+        So the scheduler only needs to reserve ``ceiling - occupied`` for a
+        request, NOT its full remaining ``max_new_tokens``. Reserving this (much
+        smaller) bound is what lets many more R-KV requests run concurrently.
+
+        The bound is deliberately the pre-compaction PEAK, so it is never an
+        underestimate: a request's physical KV can never exceed it, hence
+        admission can never over-commit the pool (memory-safe). ``occupied`` is
+        the request's current physical KV length (its committed length, or its
+        prompt length before prefill).
+        """
+        ceiling = max(prompt_len, self.config.min_seq_len) + self.config.buffer_size
+        return max(0, ceiling - occupied)
+
     # ------------------------------------------------------------------
     # Decode-time observation (called per layer from forward_decode)
     # ------------------------------------------------------------------
-    def observe_decode_layer(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        layer: "RadixAttention",
-        forward_batch: "ForwardBatch",
-    ) -> None:
-        """Observe one layer's decode step for every request in the batch.
+    def begin_decode_step(self, forward_batch: ForwardBatch) -> bool:
+        """Advance per-request decode counters and decide graph-vs-eager.
 
-        Called from ``FlashInferAttnBackend.forward_decode`` *after*
-        ``set_kv_buffer`` (new K/V already in the pool) and *before* the
-        attention wrapper runs.
+        Called once per decode step in ``ModelRunner.forward`` BEFORE the
+        graph/eager decision, so it runs on EVERY step — including steps that
+        replay a captured CUDA graph. (The per-request compaction counter must
+        advance on graph-replay steps too, which is why it lives here rather
+        than in a hook inside ``forward_decode``.)
 
-        Supports ``batch >= 1`` with **per-request triggering** (method A): each
-        request independently arms a compaction once its own KV length reaches
-        ``min_seq_len`` and ``buffer_size`` steps have elapsed since its last
-        compaction. Row ``i`` of ``q`` / ``req_pool_indices`` / ``seq_lens`` all
-        refer to the same request (decode batches are aligned, one token/req).
+        For each managed request it advances ``steps_since_compact`` (only once
+        the request is long enough to compress, ``seq_len >= min_seq_len``) and
+        arms the compaction on the final window step.
 
-        Responsibilities per request:
-          * cache this layer's query into the observation window;
-          * when a compaction is armed for this step, compute this layer's
-            per-token score and accumulate it across layers.
+        Returns True only on a compaction step (``steps_since_compact >=
+        buffer_size``): that step must run eager because ``maybe_compact`` is
+        called on the eager path (the graph path returns before it). The
+        observation-window queries are collected in-graph by
+        ``collect_decode_query``, so the window steps no longer force eager --
+        they replay the captured decode graph like any other step.
         """
-        layer_idx = layer.layer_id - self.start_layer
+        # Advance the per-request circular write cursor EVERY decode step (even
+        # with no managed requests). Vectorized over the whole batch on the GPU
+        # tensor the captured rolling_q scatter reads; begin_decode_step runs
+        # BEFORE the graph/eager decision, so this advance reaches graph-replay
+        # steps. Per-request (not one global cursor) so each request's window
+        # only advances on the steps it actually participates in — correct even
+        # if a request skips decode steps (future preemption/pipeline/overlap).
+        # Reused req_pool_idx slots are additionally protected by
+        # buffer_size >= window_size (asserted in RKVConfig), which forces
+        # >= window_size fresh writes before the first compaction, and by the
+        # on_request_begin counter reset.
+        #
+        # CUDA-graph ordering: this eager ``+= 1`` is issued on the current
+        # stream, and the captured decode graph is replayed with a plain
+        # ``cuda_graph.replay()`` on that same current stream (see the
+        # full/tc-piecewise graph backends — no stream switch; overlap and
+        # PDMux, which could introduce a second stream, are rejected for R-KV).
+        # Same-stream ops execute in issue order, so the counter update
+        # happens-before the graph read of ``step_count_of_req`` — the identical
+        # guarantee ``set_kv_buffer`` (out_cache_loc written eagerly, read
+        # in-graph) already relies on.
+        self.step_count_of_req[forward_batch.req_pool_indices] += 1
 
-        # One host sync per layer call (not per request): pull the batch's
-        # req_pool_indices and physical seq_lens to CPU.
+        if not self.states:
+            return False
         req_indices = forward_batch.req_pool_indices.tolist()
         seq_lens_src = forward_batch.seq_lens_cpu
         if seq_lens_src is None:
             seq_lens_src = forward_batch.seq_lens
         seq_lens = seq_lens_src.tolist()
 
+        buffer = self.config.buffer_size
+        need_eager = False
         for i, req_pool_idx in enumerate(req_indices):
-            req_pool_idx = int(req_pool_idx)
-            state = self.states.get(req_pool_idx)
+            state = self.states.get(int(req_pool_idx))
             if state is None:
                 continue
+            state.next_position += 1
+            # Only start the compaction clock once the request can actually be
+            # compressed; below budget there is nothing to evict.
+            if int(seq_lens[i]) < self.config.min_seq_len:
+                continue
+            state.steps_since_compact += 1
+            if state.steps_since_compact >= buffer:
+                # Compaction step: the ONLY step that must run eager, because
+                # ``maybe_compact`` runs on the eager path (the graph path
+                # returns before it). Every other decode step -- including the
+                # ``window_size`` observation-window steps ending here -- replays
+                # the captured decode graph; their queries are collected in-graph
+                # by ``collect_decode_query``. Scoring is batched across all
+                # layers in ``maybe_compact`` after the forward.
+                need_eager = True
+                self._armed.add(int(req_pool_idx))
+        return need_eager
 
-            seq_len = int(seq_lens[i])
+    def collect_decode_query(
+        self, q: torch.Tensor, layer: RadixAttention, forward_batch: ForwardBatch
+    ) -> None:
+        """In-graph rolling collection of this layer's decode query.
 
-            # Arm/advance once per step, on the first layer we see.
-            if layer_idx == 0:
-                state.begin_step()
-                if (
-                    state.steps_since_compact >= self.config.buffer_size
-                    and seq_len >= self.config.min_seq_len
-                ):
-                    self._armed.add(req_pool_idx)
-                    # Accumulator over past tokens, filled lazily below.
-                    state.score_accum = None
+        Writes ``q`` ``(bs, q_head_num, head_dim)`` into the fixed ``rolling_q``
+        buffer at each request's current circular write slot
+        (``step_count_of_req[r] % window_size``), indexed by req_pool_idx.
+        Pure-tensor scatter (no host sync / Python loop), so it is captured in
+        the decode CUDA graph and runs on graph-replay steps too -- the same
+        class of op as ``set_kv_buffer`` scattering into ``token_to_kv_pool`` at
+        ``out_cache_loc``. This is what lets observation-window steps stop
+        running eager (P3). Unconditional so CUDA-graph capture includes it.
 
-            # q[i] is (q_head_num, head_dim) for this request's single decode
-            # token; store it in the per-request ring buffer.
-            q_i = q[i]
-            state.push_query(layer_idx, q_i.reshape(q_i.shape[-2], q_i.shape[-1]))
+        CUDA-graph padding safety: a padded replay batch fills the tail
+        ``req_pool_indices`` with 0 (PaddingPolicy.ZERO), so padding rows scatter
+        their (discarded) query into ``rolling_q`` row 0 -- the reserved
+        ReqToTokenPool padding slot, never a real request -- exactly as those
+        rows write ``token_to_kv_pool`` at ``out_cache_loc`` 0. No real request's
+        observation window is corrupted.
+        """
+        layer_idx = layer.layer_id - self.start_layer
+        # This step's circular write slot per request = step_count % window.
+        # Read in-graph from the fixed-address per-request counter tensor that
+        # begin_decode_step advanced this step. Flattened index into
+        # (window * max_reqs): slot-major, req-minor.
+        req_indices = forward_batch.req_pool_indices
+        cur = self.step_count_of_req[req_indices] % self.config.window_size
+        index = cur * self._rolling_max_reqs + req_indices
+        self._rolling_q_flat[layer_idx].index_copy_(0, index, q)
 
-            if req_pool_idx in self._armed:
-                layer_score = self._layer_score(state, layer_idx, seq_len)
-                if state.score_accum is None:
-                    state.score_accum = layer_score
-                else:
-                    state.score_accum += layer_score
+    def _read_window_rolling(self, req_pool_idx: int) -> torch.Tensor:
+        """Read a request's observation window from ``rolling_q``, un-rotated to
+        temporal order (slot 0 oldest ... window-1 newest, matching
+        ``RKVRequestState.window_q``). Called at compaction (eager), so a host
+        ``roll`` is fine. Returns ``(num_layers, window_size, q_heads, head_dim)``.
+        """
+        w = self.rolling_q[:, :, req_pool_idx]  # (num_layers, window, q_heads, hd)
+        window = self.config.window_size
+        # This request's own newest write slot (per-request cursor).
+        cur = int(self.step_count_of_req[req_pool_idx].item()) % window
+        return torch.roll(w, shifts=-(cur + 1), dims=1)
 
     def _layer_score(
         self, state: RKVRequestState, layer_idx: int, seq_len: int
@@ -340,38 +479,185 @@ class RKVCompressor:
         # (num_slots, kv_heads, head_dim); gather this request's slots.
         keys = k_buffer[slots].unsqueeze(0).transpose(1, 2).contiguous()
 
-        # queries: (1, q_heads, window_size, head_dim)
-        window_q = state.ordered_window(layer_idx)  # (window, q_heads, head_dim)
+        # queries: (1, q_heads, window_size, head_dim). window_q holds the last
+        # window_size decode queries in temporal order (slot 0 oldest ..
+        # window_size-1 newest), read from the in-graph rolling collection
+        # (_read_window_rolling) at compaction time.
+        window_q = state.window_q[layer_idx]  # (window, q_heads, head_dim)
         queries = window_q.unsqueeze(0).transpose(1, 2).contiguous()
 
         # (1, kv_heads, seq_len - window) -> mean over heads -> (seq_len - window,)
         final_score = self.algo._scores(keys, queries)
         return final_score.mean(dim=1).squeeze(0)
 
+    def _reference_scores(self, state: RKVRequestState, seq_len: int) -> torch.Tensor:
+        """Per-layer sequential scoring (the original path; A/B reference).
+
+        Sums the per-layer mean-over-heads scores in layer order, exactly as the
+        old ``observe`` accumulation did. Returns ``(seq_len - window_size,)``.
+        """
+        acc: Optional[torch.Tensor] = None
+        for layer_idx in range(self.num_layers):
+            s = self._layer_score(state, layer_idx, seq_len)
+            acc = s if acc is None else acc + s
+        return acc
+
+    def _batched_scores(self, state: RKVRequestState, seq_len: int) -> torch.Tensor:
+        """Batched scoring over all layers in one GEMM (the optimization).
+
+        Gathers every layer's K for this request, stacks them into a single
+        ``(num_layers, kv_heads, seq_len, head_dim)`` batch, and runs one
+        ``algo._scores`` call (num_layers as the batch dim) instead of
+        ``num_layers`` bsz=1 calls. Cross-head mean, then cross-layer sum in
+        layer order (matching ``_reference_scores``). Chunked over layers so the
+        transient cosine-similarity matrix stays under ``_score_chunk_bytes``.
+        Returns ``(seq_len - window_size,)``.
+        """
+        r2t = self.req_to_token_pool.req_to_token
+        slots = r2t[state.req_pool_idx, :seq_len].long()
+        # window_q: (num_layers, window, q_heads, hd) -> (num_layers, q_heads, window, hd)
+        queries_all = state.window_q.transpose(1, 2).contiguous()
+
+        k0 = self.token_to_kv_pool.get_key_buffer(self.start_layer)
+        kv_heads = k0.shape[1]
+        # cosine matrix (key dtype, x2 for softmax read/write) + bool mask + int32
+        # indices, per element of (kv_heads, seq, seq) -- owner's per-pair budget.
+        per_layer = (2 * k0.element_size() + 1 + 4) * kv_heads * seq_len * seq_len
+        chunk = max(
+            1, min(self.num_layers, self._score_chunk_bytes // max(1, per_layer))
+        )
+
+        acc: Optional[torch.Tensor] = None
+        for c in range(0, self.num_layers, chunk):
+            hi = min(c + chunk, self.num_layers)
+            # (chunk, seq_len, kv_heads, hd) -> (chunk, kv_heads, seq_len, hd)
+            keys = (
+                torch.stack(
+                    [
+                        self.token_to_kv_pool.get_key_buffer(self.start_layer + l)[
+                            slots
+                        ]
+                        for l in range(c, hi)
+                    ]
+                )
+                .transpose(1, 2)
+                .contiguous()
+            )
+            # (chunk, kv_heads, seq_len - window) -> mean over heads -> (chunk, seq_len - window)
+            layer_scores = self.algo._scores(keys, queries_all[c:hi]).mean(dim=1)
+            # Sum over layers in order (matches the sequential reference).
+            for li in range(layer_scores.shape[0]):
+                s = layer_scores[li]
+                acc = s if acc is None else acc + s
+        return acc
+
     # ------------------------------------------------------------------
-    # Compaction (called once after the full forward pass)
+    # Compaction (prepare in the forward, commit at a scheduler-synced point)
     # ------------------------------------------------------------------
-    def maybe_compact(self, forward_batch: "ForwardBatch") -> None:
-        """Run physical compaction for any request armed this forward pass."""
+    def maybe_compact(self, forward_batch: ForwardBatch) -> None:
+        """Prepare physical compaction for any request armed this forward pass.
+
+        This is the **prepare** phase, run at the end of the decode forward: it
+        scores each armed request and relocates its surviving K/V to the front
+        ``budget`` slots (forward-stream compute), then appends a commit record
+        to ``_pending_commits``. The allocator free + request bookkeeping is
+        deferred to ``commit_compactions`` (called by the scheduler after the
+        forward), so allocator state is never mutated from inside the forward
+        stream. Scoring is batched across all layers (see ``_batched_scores``);
+        the first compaction runs an A/B gate against the per-layer reference.
+
+        Fail-stop contract: the relocation is in-place, so a request that raises
+        mid-relocation (OOM, a validation guard, a CUDA fault) is left partially
+        moved. Any exception raised here is therefore UNRECOVERABLE — the caller
+        (ModelRunner forward) must let it propagate and terminate the worker; it
+        must NOT be caught-and-continued, or the partially-relocated request
+        would serve corrupt KV. ``_armed`` is cleared up front (below) only so a
+        *restarted* accumulator does not inherit stale arming, not to imply the
+        current worker can recover.
+        """
         if not self._armed:
             return
 
+        # Clear the armed set up front so a mid-loop exception (Triton failure,
+        # OOM, a validation guard) cannot carry stale armed requests forward.
+        # This is fail-stop hygiene, not recovery (see the contract above).
+        armed = self._armed
+        self._armed = set()
+
         seq_len_by_req = self._seq_len_by_req(forward_batch)
-        for req_pool_idx in list(self._armed):
+        for req_pool_idx in list(armed):
+            # An armed request was armed from THIS forward's req_pool_indices in
+            # begin_decode_step, and no lifecycle hook runs between arming and
+            # here (same forward). So a missing state or seq_len is a genuine
+            # lifecycle desync, not an expected skip — fail fast rather than
+            # silently drop the compaction and let the request's KV grow.
             state = self.states.get(req_pool_idx)
-            if state is None or state.score_accum is None:
-                continue
+            if state is None:
+                raise RuntimeError(
+                    f"Armed R-KV request {req_pool_idx} has no compressor state "
+                    "(lifecycle desync between arming and compaction)"
+                )
             seq_len = seq_len_by_req.get(req_pool_idx)
             if seq_len is None:
-                continue
-            kept = self._assemble_kept(state.score_accum, seq_len)
-            self._compact_request(state, seq_len, kept)
+                raise RuntimeError(
+                    f"Armed R-KV request {req_pool_idx} is missing from the "
+                    "ForwardBatch it was armed from"
+                )
 
-        self._armed.clear()
+            # P2: the observation-window queries now come from the in-graph
+            # rolling collection (un-rotated to temporal order), not the eager
+            # window_q. Values are identical (P1 validated diff=0); this switch
+            # is what lets P3 stop forcing the window steps to run eager.
+            state.window_q = self._read_window_rolling(req_pool_idx)
 
-    def _assemble_kept(
-        self, score_accum: torch.Tensor, seq_len: int
-    ) -> torch.Tensor:
+            if self._batched_ok is None:
+                ref_kept = self._assemble_kept(
+                    self._reference_scores(state, seq_len), seq_len
+                )
+                bat_kept = self._assemble_kept(
+                    self._batched_scores(state, seq_len), seq_len
+                )
+                same_shape = ref_kept.shape == bat_kept.shape
+                self._batched_ok = bool(same_shape and torch.equal(ref_kept, bat_kept))
+                logger.info(
+                    "R-KV batched-scoring gate: %s (kept diff=%s)",
+                    (
+                        "OK -> batched adopted"
+                        if self._batched_ok
+                        else "DIFFER -> per-layer fallback"
+                    ),
+                    int((ref_kept != bat_kept).sum()) if same_shape else "shape",
+                )
+                kept = bat_kept if self._batched_ok else ref_kept
+            else:
+                score = (
+                    self._batched_scores(state, seq_len)
+                    if self._batched_ok
+                    else self._reference_scores(state, seq_len)
+                )
+                kept = self._assemble_kept(score, seq_len)
+
+            self._pending_commits.append(self._prepare_compaction(state, seq_len, kept))
+
+    def commit_compactions(self) -> None:
+        """Commit phase: apply every prepared compaction.
+
+        The scheduler calls this after the decode forward has completed (a
+        stream-synced point), *before* it releases any finished request's KV, so
+        the tail free + ``req_to_token`` clear land before ``release_kv_cache``
+        (no double-free) and the allocator is mutated with the forward stream
+        idle. No-op when nothing was prepared.
+        """
+        if not self._pending_commits:
+            return
+        # Drain up front so a mid-loop failure cannot re-commit an already-freed
+        # plan on a later call.
+        plans = self._pending_commits
+        self._pending_commits = []
+        for plan in plans:
+            self._commit_compaction(plan)
+
+    def _assemble_kept(self, score_accum: torch.Tensor, seq_len: int) -> torch.Tensor:
         """Global kept-token indices: top past tokens + trailing window.
 
         ``score_accum`` covers the past tokens ``[0, seq_len - window)``.
@@ -387,25 +673,62 @@ class RKVCompressor:
         kept = torch.cat([past_idx, window_idx])
         return torch.sort(kept).values
 
-    def _compact_request(
+    def _prepare_compaction(
         self, state: RKVRequestState, seq_len: int, kept_local: torch.Tensor
-    ) -> None:
-        """Physically compact one request's KV cache (page_size == 1).
-
-        Relocates surviving slots' K/V to the front ``budget`` slots for every
-        layer, frees the freed tail slots, rewrites ``req_to_token``, and clears
-        the tail. Kept indices must be ascending.
+    ) -> _CompactionCommit:
+        """Prepare phase (runs in the forward): relocate one request's surviving
+        K/V to the front ``budget`` slots for every layer (page_size == 1) and
+        return a commit record. Does NOT free slots, clear ``req_to_token``, or
+        touch request lengths — those are the scheduler-synced commit phase
+        (``_commit_compaction``), so the allocator is mutated only with the
+        forward stream idle. Kept indices must be ascending.
         """
         idx = state.req_pool_idx
         budget = self.config.budget
         r2t = self.req_to_token_pool.req_to_token
 
         slots = r2t[idx, :seq_len].long().clone()  # physical slots, temporal order
-        src = slots[kept_local]                    # surviving physical slots (budget,)
-        dst = slots[:budget]                       # target front slots (budget,)
+
+        # Validate the kept set and the physical slot table BEFORE mutating any
+        # buffer, so a bad score/select or a corrupt req_to_token can never write
+        # KV out of bounds, relocate from a duplicate slot, or double-free (every
+        # check is on indices only — no KV writes have happened yet). These are
+        # production safety barriers, so they RAISE rather than ``assert`` (which
+        # ``python -O`` strips). Cheap: O(seq_len), once per compaction.
+        if kept_local.numel() != budget:
+            raise RuntimeError(
+                f"R-KV kept set has {kept_local.numel()} entries, expected "
+                f"budget {budget}"
+            )
+        if kept_local.numel() > 0:
+            kept_min = int(kept_local.min())
+            kept_max = int(kept_local.max())
+            if kept_min < 0 or kept_max >= seq_len:
+                raise RuntimeError(
+                    f"R-KV kept indices out of range [0, {seq_len}): "
+                    f"[{kept_min}, {kept_max}]"
+                )
+        if not bool(torch.all(kept_local[1:] > kept_local[:-1])):
+            raise RuntimeError(
+                "R-KV kept indices must be strictly ascending (unique, sorted)"
+            )
+        # The WHOLE physical slot table for this request must be a 1-to-1 map,
+        # not just the survivors: a duplicate anywhere in slots[:seq_len] could
+        # put the same slot in both the freed tail and the kept head, so commit
+        # would free a slot req_to_token still references (use-after-free).
+        # Checking the full table subsumes the survivors-unique check.
+        if slots.unique().numel() != slots.numel():
+            raise RuntimeError(
+                "R-KV req_to_token contains duplicate physical KV slots "
+                "(allocator corruption); refusing to compact"
+            )
+
+        src = slots[kept_local]  # surviving physical slots (budget,)
+        dst = slots[:budget]  # target front slots (budget,)
 
         # Relocate K/V for every layer. Clone before write so overlapping
-        # src/dst ranges don't corrupt each other.
+        # src/dst ranges don't corrupt each other. This is forward-stream compute
+        # on the KV buffers; it does NOT touch the allocator.
         for layer_id in range(self.start_layer, self.end_layer):
             k_buffer = self.token_to_kv_pool.get_key_buffer(layer_id)
             v_buffer = self.token_to_kv_pool.get_value_buffer(layer_id)
@@ -414,16 +737,55 @@ class RKVCompressor:
             k_buffer[dst] = k_keep
             v_buffer[dst] = v_keep
 
-        # Free the tail slots (page_size == 1 => per-slot free).
-        freed = slots[budget:seq_len]
-        if freed.numel() > 0:
-            self.kv_allocator.free(freed.to(r2t.dtype))
-
-        # req_to_token[:budget] already equals ``dst`` (same physical slots),
-        # now holding the relocated kept KV in temporal order. Clear the tail.
-        r2t[idx, budget:seq_len] = 0
-
+        # Reset the trigger counter now (compressor-local state, not allocator).
         state.steps_since_compact = 0
+
+        # The tail slots [budget, seq_len) are the survivors' old homes plus the
+        # evicted tokens; they are freed in the commit phase. ``slots`` is a
+        # clone, so this stays valid after req_to_token is cleared at commit.
+        freed = slots[budget:seq_len].to(r2t.dtype)
+        return _CompactionCommit(
+            req_pool_idx=idx,
+            budget=budget,
+            seq_len=seq_len,
+            freed_slots=freed,
+            req=state.req,
+        )
+
+    def _commit_compaction(self, plan: _CompactionCommit) -> None:
+        """Commit phase (scheduler-synced): free the tail slots, clear the
+        ``req_to_token`` tail, and shrink the request's physical length.
+
+        Runs after the forward at a stream-synced scheduler point, so the
+        allocator free never races the forward. ``req_to_token[:budget]`` already
+        holds the relocated kept KV (written in the prepare phase); here we only
+        release the tail the survivors vacated.
+        """
+        idx = plan.req_pool_idx
+        budget = plan.budget
+        seq_len = plan.seq_len
+        r2t = self.req_to_token_pool.req_to_token
+
+        # Stale-plan guard: if the request slot was released or reused between
+        # prepare (forward) and this commit, the tracked identity no longer
+        # matches the plan. The prepare phase already relocated this request's
+        # K/V, so a mismatch is an unrecoverable invariant break (the scheduler
+        # order guarantees commit runs before any release), NOT something to skip
+        # — fail the worker rather than free/rewrite the wrong request's slots.
+        state = self.states.get(idx)
+        if state is None or state.req is not plan.req:
+            raise RuntimeError(
+                f"Stale R-KV compaction plan for req_pool_idx={idx}: request "
+                "slot was released or reused between prepare and commit"
+            )
+
+        # Free the tail slots (page_size == 1 => per-slot free).
+        if plan.freed_slots.numel() > 0:
+            self.kv_allocator.free(plan.freed_slots)
+
+        # req_to_token[:budget] already equals the relocated kept KV in temporal
+        # order. Clear the tail.
+        r2t[idx, budget:seq_len] = 0
 
         # Physical-length bookkeeping. The scheduler normally treats seq_lens as
         # BOTH the physical KV length AND the rotary position source; R-KV breaks
@@ -431,13 +793,13 @@ class RKVCompressor:
         # owning request here (same process, shared pools), and expose the new
         # length via ``pending_length_updates`` so the scheduler can update its
         # batch-level seq_lens / seq_lens_cpu tensors. Rotary positions stay
-        # *logical* and are supplied separately via ``logical_position`` (see the
-        # wiring notes at the bottom of the file). ``next_position`` is
-        # intentionally NOT rewound: future tokens keep their absolute positions
-        # so their rotary stays consistent with the retained keys.
-        if state.req is not None:
-            state.req.kv_committed_len = budget
-            state.req.kv_allocated_len = budget
+        # *logical* and are supplied separately via ``logical_position``.
+        # ``next_position`` is intentionally NOT rewound: future tokens keep
+        # their absolute positions so their rotary stays consistent with the
+        # retained keys.
+        if plan.req is not None:
+            plan.req.kv_committed_len = budget
+            plan.req.kv_allocated_len = budget
         self.pending_length_updates[idx] = budget
 
         logger.info(
@@ -445,14 +807,14 @@ class RKVCompressor:
             idx,
             seq_len,
             budget,
-            freed.numel(),
+            plan.freed_slots.numel(),
         )
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
     @staticmethod
-    def _seq_len_by_req(forward_batch: "ForwardBatch") -> Dict[int, int]:
+    def _seq_len_by_req(forward_batch: ForwardBatch) -> Dict[int, int]:
         """Map ``req_pool_idx -> physical seq_len`` for the current batch.
 
         Uses ``seq_lens_cpu`` when available to avoid a device sync, falling
@@ -466,7 +828,7 @@ class RKVCompressor:
         return {int(r): int(s) for r, s in zip(req_indices, seq_lens)}
 
     @staticmethod
-    def logical_position(req: "Req") -> int:
+    def logical_position(req: Req) -> int:
         """Rotary position of a request's NEXT token.
 
         Equals the total number of tokens seen so far
@@ -489,7 +851,7 @@ class RKVCompressor:
         self.pending_length_updates = {}
         return updates
 
-    def override_decode_positions(self, forward_batch: "ForwardBatch") -> None:
+    def override_decode_positions(self, forward_batch: ForwardBatch) -> None:
         """Replace decode positions with *logical* positions for R-KV requests.
 
         ``seq_lens`` now tracks the (possibly shorter) physical KV length, so
@@ -500,16 +862,27 @@ class RKVCompressor:
         """
         if forward_batch.positions is None:
             return
-        req_indices = forward_batch.req_pool_indices
-        for i in range(req_indices.shape[0]):
-            st = self.states.get(int(req_indices[i].item()))
+        # One GPU->CPU sync for the whole batch (tolist) instead of a .item()
+        # per request each decode step; collect the logical overrides and apply
+        # them in a single batched scatter rather than an element write per req.
+        req_indices = forward_batch.req_pool_indices.tolist()
+        rows: List[int] = []
+        values: List[int] = []
+        for i, req_pool_idx in enumerate(req_indices):
+            st = self.states.get(int(req_pool_idx))
             if st is not None and st.req is not None:
                 # logical_position() counts all tokens seen so far INCLUDING the
                 # token being decoded this step (it was appended to output_ids
                 # when it was sampled), so the current token's 0-based rotary
                 # position is that count minus one — for an un-compacted request
                 # this equals the baseline clamp_position(seq_lens) = seq_lens-1.
-                forward_batch.positions[i] = self.logical_position(st.req) - 1
+                rows.append(i)
+                values.append(self.logical_position(st.req) - 1)
+        if rows:
+            positions = forward_batch.positions
+            idx = torch.tensor(rows, device=positions.device, dtype=torch.long)
+            val = torch.tensor(values, device=positions.device, dtype=positions.dtype)
+            positions[idx] = val
 
 
 # ---------------------------------------------------------------------------
@@ -518,11 +891,15 @@ class RKVCompressor:
 # PHYSICAL KV length, rotary positions stay LOGICAL.
 #
 #   1. FlashInferAttnBackend.forward_decode: after set_kv_buffer, call
-#      compressor.observe_decode_layer(q, k, v, layer, forward_batch).
+#      compressor.collect_decode_query(q, layer, forward_batch) (in-graph).
 #   2. model_runner (or the backend's end-of-forward hook): after the full
-#      decode forward pass, call compressor.maybe_compact(forward_batch), then
-#      have the scheduler apply take_pending_length_updates() to batch.seq_lens
-#      / seq_lens_cpu (kv_committed_len / kv_allocated_len are already updated).
+#      decode forward pass, call compressor.maybe_compact(forward_batch) (the
+#      PREPARE phase — relocates surviving K/V, queues commit records). The
+#      scheduler then, after the forward has completed, calls
+#      compressor.commit_compactions() (the COMMIT phase — frees the evicted
+#      tail slots off the forward stream) and applies take_pending_length_updates()
+#      to batch.seq_lens / seq_lens_cpu (kv_committed_len / kv_allocated_len are
+#      updated in the commit phase).
 #   3. scheduler / schedule_batch: call on_request_begin / on_request_end around
 #      a request's life; disable overlap scheduling for phase 1 (simpler timing).
 #   4. ForwardBatch construction (forward_batch_info): for R-KV-managed requests

--- a/SGLang/rkv/prefill.py
+++ b/SGLang/rkv/prefill.py
@@ -1,0 +1,482 @@
+"""R-KV as a **prefill-phase** KV-cache compressor (pure, device-agnostic).
+
+This module uses R-KV (attention *importance* combined with key *redundancy*) to
+compress a long prompt right after prefill: keep the ``budget`` most
+important / least-redundant tokens, which adds an ``O(n^2)`` pairwise-key-similarity
+term. It implements two strategies and the primitives to diff-test one against
+the other:
+
+* **Route A — one-shot** (:meth:`RKVPrefill.oneshot_keep`): score the *whole*
+  prompt once, against the true final observation window (the last
+  ``window_size`` prompt tokens), then keep ``budget`` tokens. This is the
+  faithful R-KV semantics — no token is evicted before the entire prompt has
+  been seen — so it is the **accuracy oracle**. The only cost is the ``O(n^2)``
+  similarity; :func:`cal_similarity_tiled` computes it in row blocks so peak
+  memory is ``O(n)`` instead of ``O(n^2)``.
+
+* **Route B — buffered / chunked** (:meth:`RKVPrefill.buffered_keep`): emulate
+  chunked prefill. Feed the prompt in chunks; whenever the physical KV length
+  exceeds ``budget + buffer``, compress back to ``budget``. The similarity
+  matrix then never exceeds ``(budget + buffer + chunk_size)`` on a side, so
+  memory and per-compaction compute are bounded regardless of prompt length —
+  this is what the R-KV serving ports mean by "the buffer suppresses the
+  quadratic growth". The price is *premature eviction*: a token scored low
+  against an early, mid-prefill window is dropped irreversibly, even if a later
+  chunk would have attended to it.
+
+Both routes reduce the per-head / per-layer scores into a single global
+per-token decision exactly the way the serving integration must (one
+``req_to_token`` slot per token, shared across heads and layers):
+
+* cross-head:  **mean** of the per-head joint score.
+* cross-layer: **sum** over every layer's score.
+
+so their kept-index sets are directly comparable. See
+``test/srt/mem_cache/test_rkv_prefill.py`` for the parity + diff-test harness.
+
+Tensor conventions (per layer, batch size 1 is implied — one request at a time):
+
+* ``keys[l]``:   ``(kv_heads, n, head_dim)``
+* ``queries[l]`` / ``window_q[l]``: ``(q_heads, m, head_dim)``
+
+Grouped-query attention (``q_heads`` a multiple of ``kv_heads``) is handled the
+same way as the reference: per-group logits are pooled down to ``kv_heads``.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Sequence
+
+import torch
+import torch.nn.functional as F
+
+__all__ = ["cal_similarity_tiled", "RKVPrefill"]
+
+logger = logging.getLogger(__name__)
+
+# Lazily-loaded fused Triton redundancy kernel (CUDA-only). ``None`` = untried,
+# ``False`` = unavailable (no CUDA / no Triton), else the callable. Adoption is
+# gated per-compressor by a one-time smoke check against the tiled reference.
+_FUSED_REDUNDANCY = None
+
+
+def _get_fused_redundancy():
+    global _FUSED_REDUNDANCY
+    if _FUSED_REDUNDANCY is None:
+        try:
+            if torch.cuda.is_available():
+                from sglang.srt.mem_cache.rkv.redundancy_fused import (
+                    cal_similarity_fused,
+                )
+
+                _FUSED_REDUNDANCY = cal_similarity_fused
+            else:
+                _FUSED_REDUNDANCY = False
+        except Exception:  # pragma: no cover - triton/build issue -> fallback
+            _FUSED_REDUNDANCY = False
+    return _FUSED_REDUNDANCY
+
+
+def _attention_logits(query_states, key_states, pooling="max"):
+    """Scaled dot-product logits ``q @ k^T / sqrt(d)``, GQA-pooled to kv heads.
+
+    ``query_states``: ``(1, q_heads, q_len, head_dim)``.
+    ``key_states``:   ``(1, kv_heads, kv_len, head_dim)``.
+    Returns ``(1, kv_heads, q_len, kv_len)``.
+
+    Identical math to ``rkv.algo.compute_attention_scores`` — duplicated here so
+    this module stays importable by file path (GPU-free unit tests), matching
+    the standalone style of ``rkv/algo.py``.
+    """
+    batch_size, q_heads, q_len, head_dim = query_states.shape
+    kv_heads = key_states.shape[1]
+    group = q_heads // kv_heads
+
+    if group == 1:
+        return torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(
+            head_dim
+        )
+
+    query_states = query_states.view(batch_size, kv_heads, group, q_len, head_dim)
+    key_states = key_states.unsqueeze(2)
+    attn = torch.matmul(query_states, key_states.transpose(3, 4)) / math.sqrt(head_dim)
+    if pooling == "mean":
+        return attn.mean(dim=2)
+    if pooling == "max":
+        return attn.max(dim=2).values
+    raise ValueError("Pooling method not supported")
+
+
+def cal_similarity_tiled(
+    key_states: torch.Tensor,
+    threshold: float = 0.5,
+    retain_direction: str = "last",
+    row_block: int = 2048,
+) -> torch.Tensor:
+    """Memory-bounded redundancy score, parity-equal to ``algo.cal_similarity``.
+
+    The reference materialises the full ``(1, kv_heads, n, n)`` cosine-similarity
+    matrix, zeroes the diagonal and (per row) the most-recent above-threshold
+    neighbour, then reduces ``mean`` over the row axis and ``softmax`` over the
+    column axis. That is ``O(n^2)`` memory. Here we accumulate the per-column
+    sum in blocks of at most ``row_block`` rows, so peak memory is
+    ``O(kv_heads * row_block * n)``. The result is bit-parity (up to float
+    reduction order) with the reference for ``retain_direction='last'`` — the
+    only direction the R-KV serving path uses.
+
+    ``key_states``: ``(1, kv_heads, n, head_dim)``. Returns ``(1, kv_heads, n)``.
+    """
+    if retain_direction != "last":
+        # The reference supports other directions but the serving default (and
+        # everything we diff-test) is "last"; fall back to the exact reference
+        # for the rare other cases to avoid silently diverging.
+        from sglang.srt.mem_cache.rkv.algo import cal_similarity
+
+        return cal_similarity(
+            key_states, threshold=threshold, retain_direction=retain_direction
+        )
+
+    bsz, kv_heads, seq_len, _ = key_states.shape
+    k_norm = key_states / (key_states.norm(dim=-1, keepdim=True) + 1e-8)
+
+    col_sum = torch.zeros(
+        (bsz, kv_heads, seq_len), dtype=torch.float32, device=key_states.device
+    )
+    for r0 in range(0, seq_len, row_block):
+        r1 = min(r0 + row_block, seq_len)
+        block = k_norm[:, :, r0:r1, :]  # (1, kv_heads, B, d)
+        sim = torch.matmul(block, k_norm.transpose(-1, -2))  # (1, kv_heads, B, n)
+
+        # Zero the diagonal entries sim[:, :, li, r0 + li].
+        local = torch.arange(r1 - r0, device=key_states.device)
+        sim[:, :, local, r0 + local] = 0.0
+
+        # Per row, exempt the most-recent (largest-index) above-threshold
+        # neighbour, matching the reference's ``similarity_retain`` for
+        # retain_direction="last". Rather than materialise an int64 ``(B, n)``
+        # index tensor (the dominant temporary here), read the largest True
+        # column straight off the boolean mask: the first True scanning from the
+        # right. Rows with no above-threshold neighbour exempt column 0
+        # (``retain=0``) — exactly the reference's ``where(mask, arange, 0)``.
+        over = sim > threshold
+        has = over.any(dim=-1)
+        last_true = (seq_len - 1) - over.flip(-1).to(torch.uint8).argmax(dim=-1)
+        retain = torch.where(has, last_true, torch.zeros_like(last_true))
+        sim.scatter_(-1, retain.unsqueeze(-1), 0.0)
+
+        col_sum += sim.to(torch.float32).sum(dim=-2)  # (1, kv_heads, n)
+
+    redundancy = (col_sum / seq_len).to(key_states.dtype)
+    return redundancy.softmax(dim=-1)
+
+
+class RKVPrefill:
+    """Prefill-phase R-KV compressor with a one-shot and a buffered strategy.
+
+    Scores are reduced to one global per-token decision (head-mean, layer-sum)
+    so route A and route B produce directly comparable kept-index sets.
+    """
+
+    def __init__(
+        self,
+        budget: int = 1024,
+        window_size: int = 8,
+        kernel_size: int = 7,
+        mix_lambda: float = 0.1,
+        retain_ratio: float = 0.1,
+        retain_direction: str = "last",
+        sim_threshold: float = 0.5,
+        row_block: int = 2048,
+        fused_validation: str = "first-request",
+    ) -> None:
+        assert budget > window_size, "budget must exceed window_size"
+        self.budget = budget
+        self.window_size = window_size
+        self.kernel_size = kernel_size
+        self.mix_lambda = mix_lambda
+        self.retain_ratio = retain_ratio
+        self.retain_direction = retain_direction
+        self.sim_threshold = sim_threshold
+        self.row_block = row_block
+        # Fused redundancy backend: None=untried, False=tiled fallback, else fn.
+        self._fused_redundancy = None
+        # Fused-kernel adoption policy: "off" (never use the fused kernel),
+        # "startup" (validate once via warmup_fused_kernel), or "first-request"
+        # (lazy — validate on the first real prompt compaction).
+        self._fused_validation = fused_validation
+        if fused_validation == "off":
+            self._fused_redundancy = False
+
+    def warmup_fused_kernel(self, kv_heads, head_dim, device, dtype, seq_len=None):
+        """Startup validation of the fused redundancy kernel (prefill).
+
+        Runs the fused-vs-tiled A/B gate once on a synthetic key tensor so the
+        first (possibly long) real prompt compaction pays no gate cost and a
+        broken kernel is caught at startup. No-op unless ``fused_validation ==
+        "startup"``, ``retain_direction == "last"``, and the device is CUDA.
+        """
+        if self._fused_validation != "startup":
+            return
+        dev = torch.device(device)
+        if self.retain_direction != "last" or dev.type != "cuda":
+            return
+        if self._fused_redundancy is not None:  # already decided (e.g. "off")
+            return
+        n = int(seq_len or max(self.budget, self.window_size + 1))
+        keys = torch.randn((1, kv_heads, n, head_dim), device=dev, dtype=dtype)
+        self._redundancy_full(keys)  # triggers the lazy gate, latches the decision
+
+    # ------------------------------------------------------------------
+    # Per-layer scoring (heads reduced by mean -> one score per past token)
+    # ------------------------------------------------------------------
+    def _importance_past(
+        self, keys: torch.Tensor, window_q: torch.Tensor
+    ) -> torch.Tensor:
+        """Attention importance of each past token, averaged over kv heads.
+
+        ``keys``: ``(1, kv_heads, n, d)``; ``window_q``: ``(1, q_heads, w, d)``
+        where ``w == window_size`` and the last ``window_size`` KV entries are
+        the observation window. Returns ``(n - window_size,)``.
+        """
+        attn = _attention_logits(window_q, keys)  # (1, kv_heads, w, n)
+        attn_sum = (
+            F.softmax(
+                attn[:, :, -self.window_size :, : -self.window_size],
+                dim=-1,
+                dtype=torch.float32,
+            )
+            .mean(dim=-2)
+            .to(keys.dtype)
+        )  # (1, kv_heads, n - window)
+        attn_cache = F.max_pool1d(
+            attn_sum,
+            kernel_size=self.kernel_size,
+            padding=self.kernel_size // 2,
+            stride=1,
+        )
+        return attn_cache
+
+    def _redundancy_past(self, keys: torch.Tensor) -> torch.Tensor:
+        """Redundancy of each past token, averaged over kv heads.
+
+        On CUDA with ``retain_direction='last'`` this uses the fused Triton
+        kernel, adopted once via a smoke gate against the tiled reference (a
+        gross mismatch -> permanent tiled fallback, logged). On CPU, without
+        Triton, or for other retain directions it uses the tiled reference.
+
+        ``keys``: ``(B, kv_heads, n, d)``. Returns ``(B, kv_heads, n - window)``.
+        """
+        redundancy = self._redundancy_full(keys)
+        return redundancy[:, :, : -self.window_size]
+
+    def _tiled_redundancy(self, keys: torch.Tensor) -> torch.Tensor:
+        return cal_similarity_tiled(
+            keys,
+            threshold=self.sim_threshold,
+            retain_direction=self.retain_direction,
+            row_block=self.row_block,
+        )
+
+    def _redundancy_full(self, keys: torch.Tensor) -> torch.Tensor:
+        if self.retain_direction != "last" or not keys.is_cuda:
+            return self._tiled_redundancy(keys)
+        if self._fused_redundancy is False:
+            return self._tiled_redundancy(keys)
+        if self._fused_redundancy is not None:
+            # Adopted fused kernel. Guard against SYNCHRONOUS failures (Triton
+            # compile / shape / launch errors, wrapper bugs): degrade to the
+            # tiled reference permanently. An ASYNCHRONOUS CUDA fault (illegal
+            # access / device assert) does NOT surface here — it poisons the CUDA
+            # context and raises at a later sync point, which is (correctly)
+            # worker-fatal; we do not try to recover a poisoned context.
+            try:
+                return self._fused_redundancy(keys, threshold=self.sim_threshold)
+            except Exception as e:  # pragma: no cover - hardware/shape dependent
+                logger.warning(
+                    "R-KV-prefill fused-redundancy kernel failed at runtime (%s); "
+                    "falling back to the tiled reference permanently.",
+                    e,
+                )
+                self._fused_redundancy = False
+                return self._tiled_redundancy(keys)
+        # First CUDA call: adopt the fused kernel iff it runs AND broadly matches
+        # tiled. Any kernel failure -> permanent tiled fallback (no crash).
+        fn = _get_fused_redundancy()
+        if fn is False:
+            self._fused_redundancy = False
+            return self._tiled_redundancy(keys)
+        ref = self._tiled_redundancy(keys)
+        try:
+            got = fn(keys, threshold=self.sim_threshold)
+        except Exception as e:  # pragma: no cover - hardware/shape dependent
+            logger.warning(
+                "R-KV-prefill fused-redundancy kernel unavailable at runtime (%s); "
+                "using the tiled reference permanently.",
+                e,
+            )
+            self._fused_redundancy = False
+            return ref
+        ok = ref.shape == got.shape and torch.allclose(
+            ref.float(), got.float(), atol=1e-3, rtol=1e-2
+        )
+        self._fused_redundancy = fn if ok else False
+        logger.info(
+            "R-KV-prefill fused-redundancy gate: %s",
+            "OK -> fused adopted" if ok else "DIVERGED -> tiled fallback",
+        )
+        return got if ok else ref
+
+    def layer_past_score(
+        self, keys: torch.Tensor, window_q: torch.Tensor
+    ) -> torch.Tensor:
+        """Joint R-KV score per past token for one layer, averaged over kv heads.
+
+        Returns ``(n - window_size,)``. This mirrors
+        ``rkv.integration.RKVCompressor._layer_score`` (which does
+        ``final_score.mean(dim=1).squeeze(0)``) so serving and this diff-test
+        harness agree token-for-token.
+        """
+        importance = self._importance_past(keys, window_q)  # (1, kv_heads, n-w)
+        redundancy = self._redundancy_past(keys)  # (1, kv_heads, n-w)
+        final = importance * self.mix_lambda - redundancy * (1 - self.mix_lambda)
+        return final.mean(dim=1).squeeze(0)  # (n - window,)
+
+    def batched_past_score(
+        self, keys: torch.Tensor, window_q: torch.Tensor
+    ) -> torch.Tensor:
+        """Batched :meth:`layer_past_score` over a leading batch dim (e.g. layers).
+
+        ``keys``: ``(B, kv_heads, n, d)``; ``window_q``: ``(B, q_heads, w, d)``.
+        Returns ``(B, n - window_size)`` — the same head-mean joint score as
+        ``layer_past_score`` but without the bsz=1 ``squeeze``, so the whole
+        stack of layers is scored in one batched pass instead of a Python loop.
+        The redundancy term (fused Triton kernel, or ``cal_similarity_tiled``
+        fallback) and importance term (``_attention_logits``) both already carry
+        the batch dim, so this is a pure batching of the existing per-layer math.
+        """
+        importance = self._importance_past(keys, window_q)  # (B, kv_heads, n-w)
+        redundancy = self._redundancy_past(keys)  # (B, kv_heads, n-w)
+        final = importance * self.mix_lambda - redundancy * (1 - self.mix_lambda)
+        return final.mean(dim=1)  # (B, n - window)
+
+    def _select_from_score(
+        self, score_past: torch.Tensor, seq_len: int
+    ) -> torch.Tensor:
+        """Top past tokens + trailing window, as ascending indices (``budget``).
+
+        ``score_past`` covers past tokens ``[0, seq_len - window)``.
+        """
+        num_past = self.budget - self.window_size
+        past_idx = score_past.topk(num_past).indices
+        window_idx = torch.arange(
+            seq_len - self.window_size, seq_len, device=score_past.device
+        )
+        kept = torch.cat([past_idx, window_idx])
+        return torch.sort(kept).values
+
+    # ------------------------------------------------------------------
+    # Route A — one-shot
+    # ------------------------------------------------------------------
+    def oneshot_keep(
+        self,
+        keys: Sequence[torch.Tensor],
+        window_q: Sequence[torch.Tensor],
+    ) -> torch.Tensor:
+        """Score the whole prompt once vs the true final window (accuracy oracle).
+
+        ``keys[l]``: ``(kv_heads, n, d)`` for every layer ``l``.
+        ``window_q[l]``: ``(q_heads, window_size, d)`` — the last ``window_size``
+        prompt queries of layer ``l``.
+
+        Returns ascending original-token indices to keep, length ``budget`` (or
+        all ``n`` indices when ``n <= budget``, i.e. nothing to drop).
+        """
+        n = keys[0].shape[-2]
+        device = keys[0].device
+        if n <= self.budget:
+            return torch.arange(n, device=device)
+
+        score = None
+        for k_l, wq_l in zip(keys, window_q):
+            k = k_l.unsqueeze(0)  # (1, kv_heads, n, d)
+            wq = wq_l.unsqueeze(0)  # (1, q_heads, window, d)
+            s = self.layer_past_score(k, wq)  # (n - window,)
+            score = s if score is None else score + s
+        return self._select_from_score(score, n)
+
+    # ------------------------------------------------------------------
+    # Route B — buffered / chunked
+    # ------------------------------------------------------------------
+    def buffered_keep(
+        self,
+        keys: Sequence[torch.Tensor],
+        queries: Sequence[torch.Tensor],
+        chunk_size: int,
+        buffer: int,
+    ) -> torch.Tensor:
+        """Emulate chunked prefill with buffer-bounded compaction (route B).
+
+        Feeds the prompt in ``chunk_size``-token chunks. After a chunk lands, if
+        the physical KV length exceeds ``budget + buffer`` it compresses back to
+        ``budget`` — scoring against the window of the *current* physical KV (its
+        last ``window_size`` tokens), not the final prompt window. Peak physical
+        length (and thus the similarity side length) is bounded by
+        ``budget + buffer + chunk_size``.
+
+        ``keys[l]``:    ``(kv_heads, n, d)``; ``queries[l]``: ``(q_heads, n, d)``
+        — the full per-layer prompt keys/queries (post-rotary), indexed by
+        original token position.
+
+        Returns ascending original-token indices to keep, length ``budget`` (or
+        all ``n`` when ``n <= budget``).
+        """
+        n = keys[0].shape[-2]
+        device = keys[0].device
+        if n <= self.budget:
+            return torch.arange(n, device=device)
+
+        # Original indices currently resident in the (physical) KV, temporal.
+        kept = torch.arange(0, min(chunk_size, n), device=device)
+        pos = int(kept.numel())
+        while True:
+            if kept.numel() > self.budget + buffer:
+                kept = self._compress_buffered(keys, queries, kept)
+            if pos >= n:
+                break
+            nxt = min(pos + chunk_size, n)
+            kept = torch.cat([kept, torch.arange(pos, nxt, device=device)])
+            pos = nxt
+        # Final compaction to exactly ``budget`` before decode (real prefill
+        # always ends at budget). This last score is against the *true* final
+        # window, so ``buffer >= n`` — no mid-prefill compaction — recovers
+        # route A exactly.
+        if kept.numel() > self.budget:
+            kept = self._compress_buffered(keys, queries, kept)
+        return torch.sort(kept).values
+
+    def _compress_buffered(
+        self,
+        keys: Sequence[torch.Tensor],
+        queries: Sequence[torch.Tensor],
+        kept: torch.Tensor,
+    ) -> torch.Tensor:
+        """One buffered compaction: score current physical KV, keep ``budget``.
+
+        ``kept`` are the ascending original indices currently resident. The
+        observation window is the last ``window_size`` of them. Returns the new
+        ascending original indices (length ``budget``).
+        """
+        phys = int(kept.numel())
+        window_orig = kept[-self.window_size :]  # (window,)
+
+        score = None
+        for k_l, q_l in zip(keys, queries):
+            k = k_l.index_select(-2, kept).unsqueeze(0)  # (1, kv_heads, phys, d)
+            wq = q_l.index_select(-2, window_orig).unsqueeze(0)  # (1, q_heads, w, d)
+            s = self.layer_past_score(k, wq)  # (phys - window,)
+            score = s if score is None else score + s
+
+        local_keep = self._select_from_score(score, phys)  # local idx into kept
+        return kept.index_select(0, local_keep)

--- a/SGLang/rkv/prefill_integration.py
+++ b/SGLang/rkv/prefill_integration.py
@@ -25,7 +25,8 @@ See ``R-KV/doc/DESIGN.md`` and the A/B diff-test in
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Dict, List, Optional
+import os
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import msgspec
 import torch
@@ -65,6 +66,16 @@ class RKVPrefillConfig(msgspec.Struct):
         # can never silently start a corrupting server.
         if self.mode not in ("oneshot", "buffered"):
             raise ValueError("R-KV-prefill mode must be 'oneshot' or 'buffered'")
+        if self.window_size <= 0:
+            raise ValueError("R-KV-prefill window_size must be a positive integer")
+        if self.kernel_size <= 0 or self.kernel_size % 2 == 0:
+            raise ValueError(
+                "R-KV-prefill kernel_size must be a positive ODD integer "
+                "(an even kernel makes importance and redundancy lengths differ "
+                "by one and fails in R1KV._scores)"
+            )
+        if self.row_block <= 0:
+            raise ValueError("R-KV-prefill row_block must be a positive integer")
         if self.budget <= self.window_size:
             raise ValueError("R-KV-prefill budget must exceed window_size")
         if self.mode == "buffered" and self.buffer < 0:
@@ -117,6 +128,7 @@ class RKVPrefillCompressor:
         device: torch.device,
         enable_overlap: bool = False,
         fused_validation: str = "first-request",
+        attn_tp_group=None,
     ) -> None:
         self.config = config
         self.req_to_token_pool = req_to_token_pool
@@ -130,6 +142,17 @@ class RKVPrefillCompressor:
         # req.output_ids when the next ForwardBatch is built (one-step delay), so
         # the logical decode position must NOT subtract the extra 1.
         self.enable_overlap = enable_overlap
+
+        # Attention-TP group: each rank scores only its LOCAL kv heads, so the
+        # per-token score is summed across this group before top-k to keep the
+        # eviction decision identical on every rank (see _reduce_score_across_tp
+        # / _check_kept_consistent_across_tp). None / world_size==1 => no TP.
+        self.attn_tp_group = attn_tp_group
+        self.attn_tp_size = (
+            getattr(attn_tp_group, "world_size", 1) if attn_tp_group is not None else 1
+        )
+        self._tp_check_always = os.environ.get("SGLANG_RKV_TP_CHECK", "0") == "1"
+        self._tp_check_remaining = 8
 
         self.algo = RKVPrefill(
             budget=config.budget,
@@ -155,7 +178,7 @@ class RKVPrefillCompressor:
 
         self.states: Dict[int, RKVPrefillRequestState] = {}
         self._armed: set[int] = set()
-        self.pending_length_updates: Dict[int, int] = {}
+        self.pending_length_updates: Dict[int, Tuple[int, Req]] = {}
         # Batched-scoring A/B gate: None = not yet checked, True = batched selects
         # the same past tokens as the per-layer reference (adopted), False = they
         # differed on the first compaction (per-layer fallback forever).
@@ -189,8 +212,24 @@ class RKVPrefillCompressor:
         state.prompt_len = req.seqlen
         self.states[req.req_pool_idx] = state
 
+    def _clear_request_state(self, idx: int) -> bool:
+        """Drop all per-request prefill-R-KV bookkeeping for ``idx`` and return
+        whether a state existed. Every finish/retract path routes through here so
+        no stale pending length update / armed flag survives the release of
+        ``idx`` and gets applied to the next request that reuses the pool slot.
+        """
+        had = self.states.pop(idx, None) is not None
+        self.pending_length_updates.pop(idx, None)
+        self._armed.discard(idx)
+        return had
+
     def on_request_end(self, req: Req) -> None:
-        if req.req_pool_idx is not None and self.states.pop(req.req_pool_idx, None):
+        # Clear the pending length update / armed flag here too, not just the
+        # state: a prompt-phase request can compact at prefill end and FINISH on
+        # the same step (the normal process_batch_result_prefill finish path),
+        # releasing its pool slot. A leftover pending update would then be
+        # applied to the next request reusing this req_pool_idx.
+        if req.req_pool_idx is not None and self._clear_request_state(req.req_pool_idx):
             logger.debug(
                 "R-KV-prefill on_request_end req_pool_idx=%d states_left=%d",
                 req.req_pool_idx,
@@ -208,9 +247,7 @@ class RKVPrefillCompressor:
         idx = req.req_pool_idx
         if idx is None:
             return
-        self.states.pop(idx, None)
-        self.pending_length_updates.pop(idx, None)
-        self._armed.discard(idx)
+        self._clear_request_state(idx)
 
     def admission_steady_prompt_len(self, prompt_len: int) -> int:
         """Post-compaction resident prompt length, for compression-aware admission.
@@ -455,11 +492,16 @@ class RKVPrefillCompressor:
     ) -> torch.Tensor:
         """Cross-layer past-token score over ``slots``, batched with a first-call
         A/B gate against the per-layer reference (permanent fallback if the
-        selected past tokens differ, protecting accuracy).
+        selected past tokens differ, protecting accuracy). The score is summed
+        across the attention-TP group so every rank selects the same tokens.
         """
         if self._batched_ok is None:
-            ref = self._reference_scores(slots, window_q_all)
-            bat = self._batched_scores(slots, window_q_all)
+            ref = self._reduce_score_across_tp(
+                self._reference_scores(slots, window_q_all)
+            )
+            bat = self._reduce_score_across_tp(
+                self._batched_scores(slots, window_q_all)
+            )
             num_past = self.config.budget - self.config.window_size
             ok = ref.shape == bat.shape and ref.numel() >= num_past
             if ok:
@@ -476,11 +518,40 @@ class RKVPrefillCompressor:
                 ),
             )
             return bat if self._batched_ok else ref
-        return (
+        return self._reduce_score_across_tp(
             self._batched_scores(slots, window_q_all)
             if self._batched_ok
             else self._reference_scores(slots, window_q_all)
         )
+
+    def _reduce_score_across_tp(self, score: torch.Tensor) -> torch.Tensor:
+        """Sum the per-token score across the attention-TP group (no-op at
+        tp==1). R-KV's cross-head reduction is a linear MEAN over local heads, so
+        with uniform head sharding the all-reduced SUM is a positive scaling of
+        the true global score -> ``topk`` picks the identical tokens on every
+        rank. See ``RKVCompressor._reduce_score_across_tp`` for the full rationale.
+        """
+        if self.attn_tp_group is None or self.attn_tp_size <= 1:
+            return score
+        return self.attn_tp_group.all_reduce(score.float())
+
+    def _check_kept_consistent_across_tp(self, kept: torch.Tensor) -> None:
+        """Assert every attention-TP rank derived the identical kept set (loud
+        failure instead of silent KV divergence). Runs on the first few
+        compactions, or every one when ``SGLANG_RKV_TP_CHECK=1``."""
+        if self.attn_tp_group is None or self.attn_tp_size <= 1:
+            return
+        if not self._tp_check_always:
+            if self._tp_check_remaining <= 0:
+                return
+            self._tp_check_remaining -= 1
+        local = kept.to(torch.float32)
+        summed = self.attn_tp_group.all_reduce(local.clone())
+        if not torch.equal(summed, local * self.attn_tp_size):
+            raise RuntimeError(
+                "R-KV-prefill TP divergence: attention-TP ranks selected "
+                "different kept sets; continuing would corrupt the KV cache."
+            )
 
     # ------------------------------------------------------------------
     # Compaction (after an extend forward)
@@ -495,7 +566,9 @@ class RKVPrefillCompressor:
         if not self._armed:
             return
         r2t = self.req_to_token_pool.req_to_token
-        for req_pool_idx in list(self._armed):
+        # sorted() so every attention-TP rank issues the per-request score
+        # all-reduces in the same order.
+        for req_pool_idx in sorted(self._armed):
             state = self.states.get(req_pool_idx)
             if state is None or state.compressed or state.window_q is None:
                 continue
@@ -503,6 +576,7 @@ class RKVPrefillCompressor:
             slots = r2t[req_pool_idx, :seq_len].long()
             score = self._past_scores(slots, state.window_q)
             kept = self._assemble_kept(score, seq_len)
+            self._check_kept_consistent_across_tp(kept)
             self._compact_request(state, seq_len, kept, latch=True)
         self._armed.clear()
 
@@ -517,7 +591,9 @@ class RKVPrefillCompressor:
         one-shot, so the decode path is identical.
         """
         seq_len_by_req = self._seq_len_by_req(forward_batch)
-        for req_pool_idx, state in list(self.states.items()):
+        # sorted() so every attention-TP rank drives the per-request logical/
+        # physical compactions (and their score all-reduces) in the same order.
+        for req_pool_idx, state in sorted(self.states.items()):
             if state.compressed or state.kept_orig is None:
                 continue
             if state.prompt_len <= self.config.budget:
@@ -528,6 +604,7 @@ class RKVPrefillCompressor:
             # Final forced compaction to budget, against the true final window.
             if state.kept_orig.numel() > self.config.budget:
                 self._logical_compress(req_pool_idx, state)
+            self._check_kept_consistent_across_tp(state.kept_orig)
             self._compact_request(state, seq_len, state.kept_orig, latch=True)
 
     def _assemble_kept(self, score_accum: torch.Tensor, seq_len: int) -> torch.Tensor:
@@ -579,7 +656,7 @@ class RKVPrefillCompressor:
         if state.req is not None:
             state.req.kv_committed_len = budget
             state.req.kv_allocated_len = budget
-        self.pending_length_updates[idx] = budget
+        self.pending_length_updates[idx] = (budget, state.req)
 
         logger.info(
             "R-KV-prefill(%s) compacted req_pool_idx=%d: %d -> %d (freed %d)",
@@ -615,7 +692,7 @@ class RKVPrefillCompressor:
     def logical_position(req: Req) -> int:
         return len(req.origin_input_ids) + len(req.output_ids)
 
-    def take_pending_length_updates(self) -> Dict[int, int]:
+    def take_pending_length_updates(self) -> Dict[int, Tuple[int, Req]]:
         updates = self.pending_length_updates
         self.pending_length_updates = {}
         return updates

--- a/SGLang/rkv/prefill_integration.py
+++ b/SGLang/rkv/prefill_integration.py
@@ -1,0 +1,644 @@
+"""R-KV as a prefill-phase compressor — SGLang serving integration.
+
+Bridges the pure prefill algorithm (:mod:`sglang.srt.mem_cache.rkv.prefill`,
+:class:`RKVPrefill`) to SGLang's paged KV cache. It wires into the prompt-phase
+compression hooks (``observe_prefill_layer`` from ``forward_extend``,
+``maybe_compact`` after an extend forward, ``override_decode_positions`` at
+decode, ``on_request_begin/end`` from the scheduler). The score combines
+attention importance with a key-redundancy term (``O(n^2)`` similarity computed
+in row blocks so peak memory stays ``O(n)``).
+
+Two modes, selected by :attr:`RKVPrefillConfig.mode`:
+
+* ``"oneshot"`` (route A) — score the whole prompt once, at the end of prefill,
+  against the true final observation window (compresses once, before decode);
+  this is the accuracy oracle.
+* ``"buffered"`` (route B) — compress mid-prefill whenever the physical KV length
+  exceeds ``budget + buffer``, bounding the similarity matrix. Trades a little
+  fidelity (premature eviction) for prompt-length-independent memory. The
+  scheduler-side mid-prefill length propagation is wired in phase 2.
+
+See ``R-KV/doc/DESIGN.md`` and the A/B diff-test in
+``R-KV/benchmark/rkv_prefill_ab.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+import msgspec
+import torch
+
+from sglang.srt.mem_cache.rkv.prefill import RKVPrefill
+
+if TYPE_CHECKING:  # pragma: no cover - typing only, avoids heavy imports
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+    from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+logger = logging.getLogger(__name__)
+
+
+class RKVPrefillConfig(msgspec.Struct):
+    """Hyper-parameters for R-KV prefill compression.
+
+    Defaults mirror the R-KV reference (``window_size`` bumped to 32 for
+    prompt-phase scoring). ``mode`` picks the one-shot oracle or the
+    buffered strategy; ``buffer`` only matters for ``"buffered"``.
+    """
+
+    mode: str = "oneshot"  # "oneshot" (route A) or "buffered" (route B)
+    budget: int = 1024
+    window_size: int = 32
+    kernel_size: int = 7
+    mix_lambda: float = 0.1
+    retain_ratio: float = 0.1
+    sim_threshold: float = 0.5
+    buffer: int = 512
+    row_block: int = 2048
+
+    def __post_init__(self) -> None:
+        # Raise (not assert, which -O strips) so an invalid --rkv-prefill-config
+        # can never silently start a corrupting server.
+        if self.mode not in ("oneshot", "buffered"):
+            raise ValueError("R-KV-prefill mode must be 'oneshot' or 'buffered'")
+        if self.budget <= self.window_size:
+            raise ValueError("R-KV-prefill budget must exceed window_size")
+        if self.mode == "buffered" and self.buffer < 0:
+            raise ValueError("R-KV-prefill buffer must be non-negative")
+
+
+class RKVPrefillRequestState:
+    """Per-request bookkeeping, keyed by ``req_pool_idx``.
+
+    For ``oneshot`` it holds a cross-layer score accumulator plus a
+    per-layer buffer of the true final observation-window queries (filled across
+    chunks). For ``buffered`` the per-layer buffer instead holds the *sliding*
+    last-``window_size`` queries and ``compressed`` is never latched (a request
+    may be compacted several times as prefill progresses).
+    """
+
+    def __init__(self, req_pool_idx: int) -> None:
+        self.req_pool_idx = req_pool_idx
+        # oneshot: latched True after the single prompt compaction.
+        self.compressed = False
+        self.observed_seq_len: int = 0
+        # Full prompt length in KV tokens (set in on_request_begin).
+        self.prompt_len: int = 0
+        # Per-layer observation-window queries:
+        #   oneshot  -> the true final window (positions prompt_len-w .. prompt_len)
+        #   buffered -> the sliding last-w queries currently resident
+        # Shape (num_layers, window_size, q_heads, head_dim); lazy-allocated.
+        self.window_q: Optional[torch.Tensor] = None
+        # buffered only: number of KV tokens dropped so far by earlier
+        # compactions of THIS request (so logical positions stay correct).
+        self.dropped: int = 0
+        # buffered only: ascending ORIGINAL token indices currently kept by the
+        # logical (index-only) segmented compaction. Physical compaction at the
+        # end of prefill relocates exactly these slots. None until first chunk.
+        self.kept_orig: Optional[torch.Tensor] = None
+        self.req: Optional[Req] = None
+
+
+class RKVPrefillCompressor:
+    """R-KV prefill compressor wired into the prompt-phase compression hooks."""
+
+    def __init__(
+        self,
+        config: RKVPrefillConfig,
+        req_to_token_pool: ReqToTokenPool,
+        token_to_kv_pool: KVCache,
+        kv_allocator: BaseTokenToKVPoolAllocator,
+        start_layer: int,
+        end_layer: int,
+        device: torch.device,
+        enable_overlap: bool = False,
+        fused_validation: str = "first-request",
+    ) -> None:
+        self.config = config
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool = token_to_kv_pool
+        self.kv_allocator = kv_allocator
+        self.start_layer = start_layer
+        self.end_layer = end_layer
+        self.num_layers = end_layer - start_layer
+        self.device = device
+        # Under overlap scheduling the just-sampled token is not yet appended to
+        # req.output_ids when the next ForwardBatch is built (one-step delay), so
+        # the logical decode position must NOT subtract the extra 1.
+        self.enable_overlap = enable_overlap
+
+        self.algo = RKVPrefill(
+            budget=config.budget,
+            window_size=config.window_size,
+            kernel_size=config.kernel_size,
+            mix_lambda=config.mix_lambda,
+            retain_ratio=config.retain_ratio,
+            sim_threshold=config.sim_threshold,
+            row_block=config.row_block,
+            fused_validation=fused_validation,
+        )
+        # Startup fused-kernel validation (no-op unless fused_validation ==
+        # "startup"): warm the fused-vs-tiled gate now with the real KV head
+        # count / dtype so the first real prompt compaction pays no gate cost.
+        k0 = self.token_to_kv_pool.get_key_buffer(self.start_layer)
+        self.algo.warmup_fused_kernel(
+            kv_heads=k0.shape[1],
+            head_dim=k0.shape[-1],
+            device=device,
+            dtype=k0.dtype,
+            seq_len=config.budget,
+        )
+
+        self.states: Dict[int, RKVPrefillRequestState] = {}
+        self._armed: set[int] = set()
+        self.pending_length_updates: Dict[int, int] = {}
+        # Batched-scoring A/B gate: None = not yet checked, True = batched selects
+        # the same past tokens as the per-layer reference (adopted), False = they
+        # differed on the first compaction (per-layer fallback forever).
+        self._batched_ok: Optional[bool] = None
+        # Cap the batched-scoring transient so peak memory stays bounded for long
+        # prompts (the tiled cosine block dominates).
+        self._score_chunk_bytes: int = 512 << 20
+        # Per-forward host-side batch metadata (req_pool_indices, seq_lens,
+        # extend_lens), computed once on the first layer of each prefill forward
+        # and reused across its layers to avoid a GPU->CPU sync per layer.
+        self._prefill_meta: Optional[tuple] = None
+
+    # ------------------------------------------------------------------
+    # Request lifecycle
+    # ------------------------------------------------------------------
+    @staticmethod
+    def request_wants_compression(req: Req) -> bool:
+        """R-KV prefill compresses every request when enabled (unconditional)."""
+        return True
+
+    def on_request_begin(self, req: Req) -> None:
+        if req.req_pool_idx is None:
+            return
+        state = RKVPrefillRequestState(req_pool_idx=req.req_pool_idx)
+        state.req = req
+        # Full physical prefill length = len(origin_input_ids) + len(output_ids),
+        # NOT just the prompt. A retracted request keeps its output_ids and
+        # re-prefills origin_input_ids + output_ids, allocating that many KV
+        # slots. Keying compaction off the original prompt length would leave the
+        # regenerated output slots orphaned in the pool (KV leak).
+        state.prompt_len = req.seqlen
+        self.states[req.req_pool_idx] = state
+
+    def on_request_end(self, req: Req) -> None:
+        if req.req_pool_idx is not None and self.states.pop(req.req_pool_idx, None):
+            logger.debug(
+                "R-KV-prefill on_request_end req_pool_idx=%d states_left=%d",
+                req.req_pool_idx,
+                len(self.states),
+            )
+
+    def on_request_retract(self, req: Req) -> None:
+        """Drop state on retraction so the re-prefill rebuilds cleanly.
+
+        Must run while ``req_pool_idx`` is still valid (before the pool frees
+        it). A retained state (``compressed=True`` / stale ``observed_seq_len``)
+        would make the re-prefilled request skip compaction or free the wrong
+        tail slots, leaking KV pool memory.
+        """
+        idx = req.req_pool_idx
+        if idx is None:
+            return
+        self.states.pop(idx, None)
+        self.pending_length_updates.pop(idx, None)
+        self._armed.discard(idx)
+
+    def admission_steady_prompt_len(self, prompt_len: int) -> int:
+        """Post-compaction resident prompt length, for compression-aware admission.
+
+        A prompt-phase compressor frees the prompt down to ``budget`` at the end
+        of prefill, so a request's steady-state (decode-time) physical KV is
+        ``min(prompt_len, budget) + generated_tokens`` — NOT ``prompt_len + ...``.
+        The scheduler reserves this smaller lifetime footprint (while still
+        gating the transient full-prompt prefill on its own), which is what lets
+        many more compressed requests decode concurrently.
+        """
+        return min(prompt_len, self.config.budget)
+
+    # ------------------------------------------------------------------
+    # Prefill-time observation (per layer, from forward_extend)
+    # ------------------------------------------------------------------
+    def observe_prefill_layer(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+    ) -> None:
+        """Buffer this layer's observation-window queries (and, for oneshot, its
+        per-past-token score) for every request in the extend batch.
+
+        ``q`` is ``(num_extend_tokens, q_heads, head_dim)`` with requests
+        concatenated along dim 0; per-request slices come from
+        ``extend_seq_lens`` / ``seq_lens``.
+        """
+        layer_idx = layer.layer_id - self.start_layer
+        # req_pool_indices.tolist() is a GPU->CPU sync; the host-side batch
+        # metadata is identical for every layer of this prefill forward, so
+        # compute it ONCE on the first layer and reuse it for the rest (saves
+        # num_layers-1 syncs per prefill). forward_extend calls the layers in
+        # ascending order and R-KV runs with start_layer == 0 (tp == 1, no PP),
+        # so layer_idx == 0 is the first call of each forward and refreshes the
+        # cache — no staleness across forwards.
+        if layer_idx == 0 or self._prefill_meta is None:
+            self._prefill_meta = (
+                forward_batch.req_pool_indices.tolist(),
+                self._to_list(forward_batch.seq_lens_cpu, forward_batch.seq_lens),
+                self._to_list(
+                    forward_batch.extend_seq_lens_cpu, forward_batch.extend_seq_lens
+                ),
+            )
+        req_indices, seq_lens, extend_lens = self._prefill_meta
+        if extend_lens is None:
+            return
+
+        if self.config.mode == "buffered":
+            self._observe_buffered(q, req_indices, seq_lens, extend_lens, layer_idx)
+        else:
+            self._observe_oneshot(q, req_indices, seq_lens, extend_lens, layer_idx)
+
+    def _observe_oneshot(self, q, req_indices, seq_lens, extend_lens, layer_idx):
+        window = self.config.window_size
+        offset = 0
+        for i, req_pool_idx in enumerate(req_indices):
+            req_pool_idx = int(req_pool_idx)
+            extend_len = int(extend_lens[i])
+            start = offset
+            offset += extend_len
+
+            state = self.states.get(req_pool_idx)
+            if state is None or state.compressed:
+                continue
+            prompt_len = state.prompt_len
+            if prompt_len <= self.config.budget:
+                continue
+
+            seq_len = int(seq_lens[i])
+            prefix = seq_len - extend_len
+            w0 = prompt_len - window  # observation-window start (global index)
+
+            # Capture this chunk's slice of the true final window.
+            ov_start = max(prefix, w0)
+            ov_end = min(prefix + extend_len, prompt_len)
+            if ov_end > ov_start:
+                if state.window_q is None:
+                    q_heads, head_dim = q.shape[-2], q.shape[-1]
+                    state.window_q = torch.zeros(
+                        (self.num_layers, window, q_heads, head_dim),
+                        device=q.device,
+                        dtype=q.dtype,
+                    )
+                state.window_q[layer_idx, ov_start - w0 : ov_end - w0] = q[
+                    start + (ov_start - prefix) : start + (ov_end - prefix)
+                ]
+
+            # Arm only on the FINAL prefill chunk; scoring is batched across all
+            # layers in ``_compact_oneshot`` after the forward (not accumulated
+            # per layer here).
+            if prefix + extend_len < prompt_len:
+                continue
+            if layer_idx == 0:
+                self._armed.add(req_pool_idx)
+                state.observed_seq_len = prompt_len
+
+    def _observe_buffered(self, q, req_indices, seq_lens, extend_lens, layer_idx):
+        """Route B: maintain the sliding window and the ``kept_orig`` set, and
+        run a *logical* (index-only) compaction at each chunk boundary once the
+        kept set exceeds ``budget + buffer``.
+
+        No physical KV is freed here — the pool keeps every prompt token until
+        the single end-of-prefill physical compaction (``_compact_buffered``).
+        This keeps the extend path's logical==physical invariant intact (so
+        chunked prefill is untouched) while still reproducing Route B's
+        premature-eviction token choice and bounding the similarity matrix to
+        ``(budget + buffer)`` tokens.
+        """
+        window = self.config.window_size
+        last_layer = layer_idx == self.num_layers - 1
+        offset = 0
+        for i, req_pool_idx in enumerate(req_indices):
+            req_pool_idx = int(req_pool_idx)
+            extend_len = int(extend_lens[i])
+            start = offset
+            offset += extend_len
+
+            state = self.states.get(req_pool_idx)
+            if state is None or state.compressed:
+                continue
+            if state.prompt_len <= self.config.budget:
+                continue
+            seq_len = int(seq_lens[i])
+            prefix = seq_len - extend_len
+
+            if state.window_q is None:
+                q_heads, head_dim = q.shape[-2], q.shape[-1]
+                state.window_q = torch.zeros(
+                    (self.num_layers, window, q_heads, head_dim),
+                    device=q.device,
+                    dtype=q.dtype,
+                )
+            # Update this layer's sliding window: the last ``window`` queries
+            # seen so far. Shift older entries left when the chunk is shorter
+            # than the window (rare: chunk_size >> window in practice).
+            take = min(window, extend_len)
+            if take > 0:
+                if take < window:
+                    state.window_q[layer_idx, : window - take] = state.window_q[
+                        layer_idx, take:
+                    ].clone()
+                state.window_q[layer_idx, window - take :] = q[
+                    start + extend_len - take : start + extend_len
+                ]
+
+            # Extend the kept set with this chunk's original indices (once, at
+            # layer 0), then logically compact at the last layer (all layers'
+            # K for this chunk are now pooled and every window is refreshed).
+            if layer_idx == 0:
+                new_idx = torch.arange(prefix, prefix + extend_len, device=q.device)
+                state.kept_orig = (
+                    new_idx
+                    if state.kept_orig is None
+                    else torch.cat([state.kept_orig, new_idx])
+                )
+            if (
+                last_layer
+                and state.kept_orig is not None
+                and state.kept_orig.numel() > self.config.budget + self.config.buffer
+            ):
+                self._logical_compress(req_pool_idx, state)
+
+    def _logical_compress(self, req_pool_idx: int, state) -> None:
+        """Score the current ``kept_orig`` set (all layers summed) against the
+        sliding window and shrink it to ``budget`` — index-only, no KV moves.
+        """
+        kept = state.kept_orig
+        r2t = self.req_to_token_pool.req_to_token
+        phys_slots = r2t[req_pool_idx, kept].long()
+        score = self._past_scores(phys_slots, state.window_q)
+        local = self.algo._select_from_score(score, kept.numel())
+        state.kept_orig = kept.index_select(0, local)
+
+    def _reference_scores(
+        self, slots: torch.Tensor, window_q_all: torch.Tensor
+    ) -> torch.Tensor:
+        """Per-layer sequential scoring over ``slots`` (original path; A/B ref).
+
+        Sums the per-layer head-mean scores in layer order. ``slots`` are the
+        physical KV slots to score; ``window_q_all`` is
+        ``(num_layers, window, q_heads, head_dim)``. Returns
+        ``(len(slots) - window_size,)``.
+        """
+        acc: Optional[torch.Tensor] = None
+        for layer_idx in range(self.num_layers):
+            layer_id = self.start_layer + layer_idx
+            k_buffer = self.token_to_kv_pool.get_key_buffer(layer_id)
+            keys = k_buffer[slots].unsqueeze(0).transpose(1, 2).contiguous()
+            queries = window_q_all[layer_idx].unsqueeze(0).transpose(1, 2).contiguous()
+            s = self.algo.layer_past_score(keys, queries)
+            acc = s if acc is None else acc + s
+        return acc
+
+    def _batched_scores(
+        self, slots: torch.Tensor, window_q_all: torch.Tensor
+    ) -> torch.Tensor:
+        """Batched all-layer scoring over ``slots`` in one pass per chunk.
+
+        Stacks every layer's K for ``slots`` into one
+        ``(chunk, kv_heads, n, head_dim)`` batch and runs one
+        ``algo.batched_past_score`` (num_layers as the batch dim) instead of
+        ``num_layers`` bsz=1 calls, then cross-layer sum in layer order (matching
+        ``_reference_scores``). Chunked over layers so the tiled cosine transient
+        stays under ``_score_chunk_bytes``. Returns ``(len(slots) - window,)``.
+        """
+        queries_all = window_q_all.transpose(1, 2).contiguous()  # (L, q_heads, w, hd)
+        n = int(slots.numel())
+        k0 = self.token_to_kv_pool.get_key_buffer(self.start_layer)
+        kv_heads = k0.shape[1]
+        # The tiled cosine block (fp32, kv_heads x row_block x n) dominates peak.
+        row_block = min(self.config.row_block, n)
+        per_layer = max(1, 4 * kv_heads * row_block * n)
+        chunk = max(1, min(self.num_layers, self._score_chunk_bytes // per_layer))
+
+        acc: Optional[torch.Tensor] = None
+        for c in range(0, self.num_layers, chunk):
+            hi = min(c + chunk, self.num_layers)
+            keys = (
+                torch.stack(
+                    [
+                        self.token_to_kv_pool.get_key_buffer(self.start_layer + l)[
+                            slots
+                        ]
+                        for l in range(c, hi)
+                    ]
+                )
+                .transpose(1, 2)
+                .contiguous()
+            )  # (chunk, kv_heads, n, hd)
+            layer_scores = self.algo.batched_past_score(keys, queries_all[c:hi])
+            for li in range(layer_scores.shape[0]):
+                s = layer_scores[li]
+                acc = s if acc is None else acc + s
+        return acc
+
+    def _past_scores(
+        self, slots: torch.Tensor, window_q_all: torch.Tensor
+    ) -> torch.Tensor:
+        """Cross-layer past-token score over ``slots``, batched with a first-call
+        A/B gate against the per-layer reference (permanent fallback if the
+        selected past tokens differ, protecting accuracy).
+        """
+        if self._batched_ok is None:
+            ref = self._reference_scores(slots, window_q_all)
+            bat = self._batched_scores(slots, window_q_all)
+            num_past = self.config.budget - self.config.window_size
+            ok = ref.shape == bat.shape and ref.numel() >= num_past
+            if ok:
+                ref_top = torch.sort(ref.topk(num_past).indices).values
+                bat_top = torch.sort(bat.topk(num_past).indices).values
+                ok = bool(torch.equal(ref_top, bat_top))
+            self._batched_ok = ok
+            logger.info(
+                "R-KV-prefill batched-scoring gate: %s",
+                (
+                    "OK -> batched adopted"
+                    if self._batched_ok
+                    else "DIFFER -> per-layer fallback"
+                ),
+            )
+            return bat if self._batched_ok else ref
+        return (
+            self._batched_scores(slots, window_q_all)
+            if self._batched_ok
+            else self._reference_scores(slots, window_q_all)
+        )
+
+    # ------------------------------------------------------------------
+    # Compaction (after an extend forward)
+    # ------------------------------------------------------------------
+    def maybe_compact(self, forward_batch: ForwardBatch) -> None:
+        if self.config.mode == "buffered":
+            self._compact_buffered(forward_batch)
+        else:
+            self._compact_oneshot()
+
+    def _compact_oneshot(self) -> None:
+        if not self._armed:
+            return
+        r2t = self.req_to_token_pool.req_to_token
+        for req_pool_idx in list(self._armed):
+            state = self.states.get(req_pool_idx)
+            if state is None or state.compressed or state.window_q is None:
+                continue
+            seq_len = state.observed_seq_len
+            slots = r2t[req_pool_idx, :seq_len].long()
+            score = self._past_scores(slots, state.window_q)
+            kept = self._assemble_kept(score, seq_len)
+            self._compact_request(state, seq_len, kept, latch=True)
+        self._armed.clear()
+
+    def _compact_buffered(self, forward_batch: ForwardBatch) -> None:
+        """End-of-prefill physical compaction to ``kept_orig`` (route B).
+
+        Fires only on a request's FINAL prefill chunk (``seq_len ==
+        prompt_len``). By then ``kept_orig`` holds the buffered logical
+        selection; a final forced shrink to ``budget`` (scored against the true
+        final window) matches the pure algorithm, then the surviving slots are
+        physically relocated to the front and the tail is freed — exactly like
+        one-shot, so the decode path is identical.
+        """
+        seq_len_by_req = self._seq_len_by_req(forward_batch)
+        for req_pool_idx, state in list(self.states.items()):
+            if state.compressed or state.kept_orig is None:
+                continue
+            if state.prompt_len <= self.config.budget:
+                continue
+            seq_len = seq_len_by_req.get(req_pool_idx)
+            if seq_len is None or seq_len < state.prompt_len:
+                continue  # not the final prefill chunk yet
+            # Final forced compaction to budget, against the true final window.
+            if state.kept_orig.numel() > self.config.budget:
+                self._logical_compress(req_pool_idx, state)
+            self._compact_request(state, seq_len, state.kept_orig, latch=True)
+
+    def _assemble_kept(self, score_accum: torch.Tensor, seq_len: int) -> torch.Tensor:
+        """Top past tokens + trailing window, ascending, length ``budget``."""
+        num_past = self.config.budget - self.config.window_size
+        past_idx = score_accum.topk(num_past).indices
+        window_idx = torch.arange(
+            seq_len - self.config.window_size, seq_len, device=score_accum.device
+        )
+        return torch.sort(torch.cat([past_idx, window_idx])).values
+
+    def _compact_request(
+        self,
+        state: RKVPrefillRequestState,
+        seq_len: int,
+        kept_local: torch.Tensor,
+        latch: bool,
+    ) -> None:
+        """Physically compact one request's KV to ``budget`` slots (page_size 1)."""
+        idx = state.req_pool_idx
+        budget = self.config.budget
+        r2t = self.req_to_token_pool.req_to_token
+
+        slots = r2t[idx, :seq_len].long().clone()
+        src = slots[kept_local]
+        dst = slots[:budget]
+
+        for layer_id in range(self.start_layer, self.end_layer):
+            k_buffer = self.token_to_kv_pool.get_key_buffer(layer_id)
+            v_buffer = self.token_to_kv_pool.get_value_buffer(layer_id)
+            k_keep = k_buffer[src].clone()
+            v_keep = v_buffer[src].clone()
+            k_buffer[dst] = k_keep
+            v_buffer[dst] = v_keep
+
+        freed = slots[budget:seq_len]
+        if freed.numel() > 0:
+            self.kv_allocator.free(freed.to(r2t.dtype))
+        r2t[idx, budget:seq_len] = 0
+
+        if latch:
+            state.compressed = True
+            state.window_q = None
+        else:
+            # buffered: track how many tokens were dropped so logical positions
+            # of subsequent chunks stay correct.
+            state.dropped += seq_len - budget
+
+        if state.req is not None:
+            state.req.kv_committed_len = budget
+            state.req.kv_allocated_len = budget
+        self.pending_length_updates[idx] = budget
+
+        logger.info(
+            "R-KV-prefill(%s) compacted req_pool_idx=%d: %d -> %d (freed %d)",
+            self.config.mode,
+            idx,
+            seq_len,
+            budget,
+            freed.numel(),
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _to_list(cpu_src, dev_src) -> Optional[List[int]]:
+        src = cpu_src if cpu_src is not None else dev_src
+        if src is None:
+            return None
+        if isinstance(src, list):
+            return src
+        return src.tolist()
+
+    @staticmethod
+    def _seq_len_by_req(forward_batch: ForwardBatch) -> Dict[int, int]:
+        req_indices = forward_batch.req_pool_indices.tolist()
+        src = forward_batch.seq_lens_cpu
+        if src is None:
+            src = forward_batch.seq_lens
+        seq_lens = src.tolist()
+        return {int(r): int(s) for r, s in zip(req_indices, seq_lens)}
+
+    @staticmethod
+    def logical_position(req: Req) -> int:
+        return len(req.origin_input_ids) + len(req.output_ids)
+
+    def take_pending_length_updates(self) -> Dict[int, int]:
+        updates = self.pending_length_updates
+        self.pending_length_updates = {}
+        return updates
+
+    def override_decode_positions(self, forward_batch: ForwardBatch) -> None:
+        if forward_batch.positions is None:
+            return
+        # One GPU->CPU sync for the whole batch (tolist) instead of a .item()
+        # per request each decode step; apply the logical overrides in a single
+        # batched scatter rather than an element write per managed request.
+        req_indices = forward_batch.req_pool_indices.tolist()
+        offset = 0 if self.enable_overlap else 1
+        rows: List[int] = []
+        values: List[int] = []
+        for i, req_pool_idx in enumerate(req_indices):
+            st = self.states.get(int(req_pool_idx))
+            if st is not None and st.req is not None:
+                # Overlap delays output_ids by one token, so logical_position is
+                # already one short then; drop the -1 in that case.
+                rows.append(i)
+                values.append(self.logical_position(st.req) - offset)
+        if rows:
+            positions = forward_batch.positions
+            idx = torch.tensor(rows, device=positions.device, dtype=torch.long)
+            val = torch.tensor(values, device=positions.device, dtype=positions.dtype)
+            positions[idx] = val

--- a/SGLang/rkv/redundancy_fused.py
+++ b/SGLang/rkv/redundancy_fused.py
@@ -1,0 +1,237 @@
+"""Fused Triton redundancy kernel for R-KV prefill (Stage 1: no retain-exemption).
+
+Computes the R-KV redundancy signal::
+
+    redundancy = softmax_j( (1/n) * sum_i simcos(i, j) )
+
+where ``simcos`` is the normalized-key cosine similarity with the diagonal
+zeroed, *without* the per-row "retain the most-recent above-threshold
+neighbour" exemption. The ``n x n`` similarity matrix is never materialised:
+each ``(row-block, col-block)`` tile is formed in registers via ``tl.dot`` and
+reduced into a per-column running sum, so HBM traffic is ``O(n*d)`` reads of the
+(pre-normalized) keys plus an ``O(n)`` write of the column sums — instead of the
+``O(n^2)`` write+reread of the materialised matrix in ``cal_similarity_tiled``.
+
+The kernel is **col-parallel**: one program owns ``BLOCK_N`` output columns and
+loops over all rows, accumulating the column sum locally (no atomics). Stage 2
+adds the retain exemption as a cheap ``O(n)``-atomics correction to reach
+bit-parity with ``algo.cal_similarity`` / ``cal_similarity_tiled``.
+
+This module imports ``triton`` at load time, so it is only imported on the CUDA
+serving path; the CPU-by-path unit tests exercise ``cal_similarity_tiled``.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _colsum_kernel(
+    K_ptr,  # (H, N, D) normalized keys
+    OUT_ptr,  # (H, N) fp32 column sums
+    N,
+    D,
+    stride_kh,
+    stride_kn,
+    stride_kd,
+    stride_oh,
+    stride_on,
+    BLOCK_N: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    h = tl.program_id(0)
+    col_pid = tl.program_id(1)
+
+    cols = col_pid * BLOCK_N + tl.arange(0, BLOCK_N)  # (BLOCK_N,)
+    col_mask = cols < N
+    d = tl.arange(0, BLOCK_D)
+    d_mask = d < D
+
+    # Columns this program owns: K[h, cols, :] -> (BLOCK_N, BLOCK_D)
+    kcol = tl.load(
+        K_ptr + h * stride_kh + cols[:, None] * stride_kn + d[None, :] * stride_kd,
+        mask=col_mask[:, None] & d_mask[None, :],
+        other=0.0,
+    )
+    kcol_t = tl.trans(kcol)  # (BLOCK_D, BLOCK_N)
+
+    acc = tl.zeros((BLOCK_N,), dtype=tl.float32)
+    for row0 in range(0, N, BLOCK_M):
+        rows = row0 + tl.arange(0, BLOCK_M)  # (BLOCK_M,)
+        row_mask = rows < N
+        krow = tl.load(
+            K_ptr + h * stride_kh + rows[:, None] * stride_kn + d[None, :] * stride_kd,
+            mask=row_mask[:, None] & d_mask[None, :],
+            other=0.0,
+        )  # (BLOCK_M, BLOCK_D)
+        sim = tl.dot(krow, kcol_t, input_precision="ieee")  # (BLOCK_M, BLOCK_N) fp32
+        # Zero the diagonal (self-similarity) and any padded rows/cols.
+        diag = rows[:, None] == cols[None, :]
+        drop = diag | (~row_mask[:, None]) | (~col_mask[None, :])
+        sim = tl.where(drop, 0.0, sim)
+        acc += tl.sum(sim, axis=0)  # (BLOCK_N,)
+
+    tl.store(OUT_ptr + h * stride_oh + cols * stride_on, acc, mask=col_mask)
+
+
+def cal_similarity_fused_noretain(
+    key_states: torch.Tensor,
+    block_n: int = 128,
+    block_m: int = 64,
+) -> torch.Tensor:
+    """Fused redundancy WITHOUT the retain exemption.
+
+    ``key_states``: ``(bsz, kv_heads, n, d)``. Returns ``(bsz, kv_heads, n)``.
+    Matches a reference that zeroes only the diagonal (no ``similarity_retain``).
+    """
+    bsz, kv_heads, n, d = key_states.shape
+    h = bsz * kv_heads
+    k = key_states.reshape(h, n, d)
+    k_norm = (k / (k.norm(dim=-1, keepdim=True) + 1e-8)).contiguous()
+    out = torch.empty((h, n), dtype=torch.float32, device=k.device)
+
+    block_d = triton.next_power_of_2(d)
+    grid = (h, triton.cdiv(n, block_n))
+    _colsum_kernel[grid](
+        k_norm,
+        out,
+        n,
+        d,
+        k_norm.stride(0),
+        k_norm.stride(1),
+        k_norm.stride(2),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_N=block_n,
+        BLOCK_M=block_m,
+        BLOCK_D=block_d,
+    )
+    redundancy = (out / n).softmax(dim=-1)
+    return redundancy.reshape(bsz, kv_heads, n).to(key_states.dtype)
+
+
+@triton.jit
+def _colsum_retain_kernel(
+    K_ptr,  # (H, N, D) normalized keys
+    OUT_ptr,  # (H, N) fp32 column sums, pre-zeroed
+    N,
+    D,
+    threshold,
+    stride_kh,
+    stride_kn,
+    stride_kd,
+    stride_oh,
+    stride_on,
+    BLOCK_N: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    """Row-parallel: one program owns BLOCK_M rows, sees the full row, so it can
+    find the per-row retain column (largest column with cos > threshold). It
+    atomically accumulates the column sums and, at the end, subtracts the single
+    exempted entry per row — matching the reference's ``similarity_retain``.
+    """
+    h = tl.program_id(0)
+    row_pid = tl.program_id(1)
+
+    rows = row_pid * BLOCK_M + tl.arange(0, BLOCK_M)  # (BLOCK_M,)
+    row_mask = rows < N
+    d = tl.arange(0, BLOCK_D)
+    d_mask = d < D
+    krow = tl.load(
+        K_ptr + h * stride_kh + rows[:, None] * stride_kn + d[None, :] * stride_kd,
+        mask=row_mask[:, None] & d_mask[None, :],
+        other=0.0,
+    )  # (BLOCK_M, BLOCK_D)
+
+    retain_col = tl.zeros((BLOCK_M,), dtype=tl.int32)  # default column 0
+    retain_val = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    has_any = tl.zeros((BLOCK_M,), dtype=tl.int32)
+    val_at_col0 = tl.zeros((BLOCK_M,), dtype=tl.float32)
+
+    for col0 in range(0, N, BLOCK_N):
+        cols = col0 + tl.arange(0, BLOCK_N)  # (BLOCK_N,)
+        col_mask = cols < N
+        kcol = tl.load(
+            K_ptr + h * stride_kh + cols[:, None] * stride_kn + d[None, :] * stride_kd,
+            mask=col_mask[:, None] & d_mask[None, :],
+            other=0.0,
+        )  # (BLOCK_N, BLOCK_D)
+        sim = tl.dot(krow, tl.trans(kcol), input_precision="ieee")  # (BLOCK_M, BLOCK_N)
+        diag = rows[:, None] == cols[None, :]
+        drop = diag | (~row_mask[:, None]) | (~col_mask[None, :])
+        sim = tl.where(drop, 0.0, sim)
+
+        # Accumulate the (un-exempted) column sum.
+        tl.atomic_add(
+            OUT_ptr + h * stride_oh + cols * stride_on,
+            tl.sum(sim, axis=0),
+            mask=col_mask,
+        )
+
+        # Capture sim[:, 0] for the default (no-neighbour) retain. Column 0 lives
+        # only in the first block, so this is nonzero there and zero elsewhere.
+        val_at_col0 += tl.sum(tl.where(cols[None, :] == 0, sim, 0.0), axis=1)
+
+        # Largest above-threshold column in this block (forward sweep => later
+        # blocks always dominate), and its similarity value.
+        over = sim > threshold
+        cand = tl.where(over, cols[None, :].to(tl.int32), -1)
+        blk_max_col = tl.max(cand, axis=1)  # (BLOCK_M,), -1 if none
+        has_blk = blk_max_col >= 0
+        is_bmc = cols[None, :].to(tl.int32) == blk_max_col[:, None]
+        blk_val = tl.sum(tl.where(is_bmc, sim, 0.0), axis=1)  # (BLOCK_M,)
+        retain_col = tl.where(has_blk, blk_max_col, retain_col)
+        retain_val = tl.where(has_blk, blk_val, retain_val)
+        has_any = tl.where(has_blk, 1, has_any)
+
+    final_col = tl.where(has_any > 0, retain_col, 0)
+    final_val = tl.where(has_any > 0, retain_val, val_at_col0)
+    # Exempt the single retained entry per row.
+    tl.atomic_add(
+        OUT_ptr + h * stride_oh + final_col * stride_on,
+        -final_val,
+        mask=row_mask,
+    )
+
+
+def cal_similarity_fused(
+    key_states: torch.Tensor,
+    threshold: float = 0.5,
+    block_n: int = 64,
+    block_m: int = 128,
+) -> torch.Tensor:
+    """Fused redundancy WITH the retain exemption (bit-parity target:
+    ``algo.cal_similarity`` / ``cal_similarity_tiled`` for retain_direction='last').
+
+    ``key_states``: ``(bsz, kv_heads, n, d)``. Returns ``(bsz, kv_heads, n)``.
+    """
+    bsz, kv_heads, n, d = key_states.shape
+    h = bsz * kv_heads
+    k = key_states.reshape(h, n, d)
+    k_norm = (k / (k.norm(dim=-1, keepdim=True) + 1e-8)).contiguous()
+    out = torch.zeros((h, n), dtype=torch.float32, device=k.device)
+
+    block_d = triton.next_power_of_2(d)
+    grid = (h, triton.cdiv(n, block_m))
+    _colsum_retain_kernel[grid](
+        k_norm,
+        out,
+        n,
+        d,
+        float(threshold),
+        k_norm.stride(0),
+        k_norm.stride(1),
+        k_norm.stride(2),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_N=block_n,
+        BLOCK_M=block_m,
+        BLOCK_D=block_d,
+    )
+    redundancy = (out / n).softmax(dim=-1)
+    return redundancy.reshape(bsz, kv_heads, n).to(key_states.dtype)

--- a/SGLang/scripts/apply_rkv.sh
+++ b/SGLang/scripts/apply_rkv.sh
@@ -5,7 +5,7 @@
 # What it does (all pinned, no surprises):
 #   1. Clones upstream SGLang at the EXACT commit R-KV was ported against.
 #   2. Copies the standalone R-KV package (rkv/) into the SGLang source tree.
-#   3. Applies the small wiring patch (5 files) that hooks R-KV into the runtime.
+#   3. Applies the small wiring patch (9 files) that hooks R-KV into the runtime.
 #
 # After this, run the server with benchmark/launch_server.sh (it points
 # PYTHONPATH at the tree produced here).
@@ -52,7 +52,7 @@ mkdir -p "$DEST"
 cp "$HERE"/rkv/*.py "$DEST"/
 echo "         copied $(ls "$HERE"/rkv/*.py | wc -l | tr -d ' ') files -> $DEST"
 
-echo ">> [3/3] Applying R-KV wiring patch (5 files)"
+echo ">> [3/3] Applying R-KV wiring patch (9 files)"
 git -C "$SGLANG_SRC" apply --check "$PATCH"     # fail loudly if it won't apply cleanly
 git -C "$SGLANG_SRC" apply --whitespace=nowarn "$PATCH"
 echo "         patch applied cleanly"

--- a/SGLang/tests/test_rkv_algo.py
+++ b/SGLang/tests/test_rkv_algo.py
@@ -8,7 +8,7 @@ disabled by default) is compared against
 
 Run directly::
 
-    python tests/test_rkv_algo.py
+    python test/srt/mem_cache/test_rkv_algo.py
 
 or under a test runner (unittest / pytest).
 """
@@ -28,7 +28,8 @@ import torch.nn.functional as F
 _ALGO_PATH = os.path.join(
     os.path.dirname(__file__),
     "..",
-    "rkv", "algo.py",
+    "rkv",
+    "algo.py",
 )
 _spec = importlib.util.spec_from_file_location("rkv_algo", os.path.abspath(_ALGO_PATH))
 _algo = importlib.util.module_from_spec(_spec)
@@ -66,7 +67,9 @@ def ref_compute_attention_scores(query_states, key_states, pooling="max"):
     return attn_weights
 
 
-def ref_cal_similarity(key_states, threshold=0.5, retain_ratio=0.2, retain_direction="last"):
+def ref_cal_similarity(
+    key_states, threshold=0.5, retain_ratio=0.2, retain_direction="last"
+):
     _, _, seq_len, _ = key_states.shape
 
     k_norm = key_states / (key_states.norm(dim=-1, keepdim=True) + 1e-8)
@@ -149,8 +152,12 @@ class RefR1KV:
         )
         indices = final_score.topk(self.budget - self.window_size, dim=-1).indices
         indices = indices.unsqueeze(-1).expand(-1, -1, -1, head_dim)
-        k_past_compress = key_states[:, :, : -self.window_size, :].gather(dim=2, index=indices)
-        v_past_compress = value_states[:, :, : -self.window_size, :].gather(dim=2, index=indices)
+        k_past_compress = key_states[:, :, : -self.window_size, :].gather(
+            dim=2, index=indices
+        )
+        v_past_compress = value_states[:, :, : -self.window_size, :].gather(
+            dim=2, index=indices
+        )
         k_cur = key_states[:, :, -self.window_size :, :]
         v_cur = value_states[:, :, -self.window_size :, :]
         key_states = torch.cat([k_past_compress, k_cur], dim=2)
@@ -163,10 +170,42 @@ class RefR1KV:
 # --------------------------------------------------------------------------- #
 CONFIGS = [
     # (bsz, q_heads, kv_heads, seq_len, head_dim, budget, window_size)
-    dict(bsz=1, q_heads=8, kv_heads=8, seq_len=256, head_dim=64, budget=128, window_size=8),
-    dict(bsz=1, q_heads=32, kv_heads=8, seq_len=300, head_dim=128, budget=192, window_size=16),  # GQA
-    dict(bsz=2, q_heads=8, kv_heads=8, seq_len=200, head_dim=64, budget=100, window_size=8),
-    dict(bsz=1, q_heads=16, kv_heads=16, seq_len=100, head_dim=64, budget=128, window_size=8),  # below budget
+    dict(
+        bsz=1,
+        q_heads=8,
+        kv_heads=8,
+        seq_len=256,
+        head_dim=64,
+        budget=128,
+        window_size=8,
+    ),
+    dict(
+        bsz=1,
+        q_heads=32,
+        kv_heads=8,
+        seq_len=300,
+        head_dim=128,
+        budget=192,
+        window_size=16,
+    ),  # GQA
+    dict(
+        bsz=2,
+        q_heads=8,
+        kv_heads=8,
+        seq_len=200,
+        head_dim=64,
+        budget=100,
+        window_size=8,
+    ),
+    dict(
+        bsz=1,
+        q_heads=16,
+        kv_heads=16,
+        seq_len=100,
+        head_dim=64,
+        budget=128,
+        window_size=8,
+    ),  # below budget
 ]
 
 KWARGS = dict(kernel_size=7, mix_lambda=0.1, retain_ratio=0.1, retain_direction="last")
@@ -174,9 +213,15 @@ KWARGS = dict(kernel_size=7, mix_lambda=0.1, retain_ratio=0.1, retain_direction=
 
 def _make_inputs(cfg, seed):
     g = torch.Generator().manual_seed(seed)
-    q = torch.randn(cfg["bsz"], cfg["q_heads"], cfg["seq_len"], cfg["head_dim"], generator=g)
-    k = torch.randn(cfg["bsz"], cfg["kv_heads"], cfg["seq_len"], cfg["head_dim"], generator=g)
-    v = torch.randn(cfg["bsz"], cfg["kv_heads"], cfg["seq_len"], cfg["head_dim"], generator=g)
+    q = torch.randn(
+        cfg["bsz"], cfg["q_heads"], cfg["seq_len"], cfg["head_dim"], generator=g
+    )
+    k = torch.randn(
+        cfg["bsz"], cfg["kv_heads"], cfg["seq_len"], cfg["head_dim"], generator=g
+    )
+    v = torch.randn(
+        cfg["bsz"], cfg["kv_heads"], cfg["seq_len"], cfg["head_dim"], generator=g
+    )
     return q, k, v
 
 
@@ -185,18 +230,26 @@ class TestRKVAlgoParity(unittest.TestCase):
         for i, cfg in enumerate(CONFIGS):
             with self.subTest(config=i):
                 q, k, v = _make_inputs(cfg, seed=1000 + i)
-                mine = R1KV(budget=cfg["budget"], window_size=cfg["window_size"], **KWARGS)
-                ref = RefR1KV(budget=cfg["budget"], window_size=cfg["window_size"], **KWARGS)
+                mine = R1KV(
+                    budget=cfg["budget"], window_size=cfg["window_size"], **KWARGS
+                )
+                ref = RefR1KV(
+                    budget=cfg["budget"], window_size=cfg["window_size"], **KWARGS
+                )
 
                 mk, mv = mine.update_kv(k.clone(), q.clone(), v.clone())
                 rk, rv = ref.update_kv(k.clone(), q.clone(), v.clone())
 
                 self.assertEqual(mk.shape, rk.shape)
                 self.assertEqual(mv.shape, rv.shape)
-                self.assertTrue(torch.allclose(mk, rk, atol=1e-6, rtol=0),
-                                msg=f"key mismatch cfg {i}")
-                self.assertTrue(torch.allclose(mv, rv, atol=1e-6, rtol=0),
-                                msg=f"value mismatch cfg {i}")
+                self.assertTrue(
+                    torch.allclose(mk, rk, atol=1e-6, rtol=0),
+                    msg=f"key mismatch cfg {i}",
+                )
+                self.assertTrue(
+                    torch.allclose(mv, rv, atol=1e-6, rtol=0),
+                    msg=f"value mismatch cfg {i}",
+                )
 
     def test_below_budget_is_noop(self):
         cfg = CONFIGS[3]  # seq_len < budget
@@ -213,7 +266,9 @@ class TestRKVAlgoParity(unittest.TestCase):
                 continue
             with self.subTest(config=i):
                 q, k, v = _make_inputs(cfg, seed=2000 + i)
-                mine = R1KV(budget=cfg["budget"], window_size=cfg["window_size"], **KWARGS)
+                mine = R1KV(
+                    budget=cfg["budget"], window_size=cfg["window_size"], **KWARGS
+                )
 
                 idx = mine.select_indices(k, q, sort=True)
                 self.assertEqual(
@@ -229,12 +284,15 @@ class TestRKVAlgoParity(unittest.TestCase):
                 # compressed keys from update_kv.
                 mk, _ = mine.update_kv(k.clone(), q.clone(), v.clone())
                 gathered = torch.gather(
-                    k, dim=2,
+                    k,
+                    dim=2,
                     index=idx.unsqueeze(-1).expand(-1, -1, -1, cfg["head_dim"]),
                 )
                 # sort both along seq dim by a stable key to compare sets
                 self.assertEqual(gathered.shape, mk.shape)
-                gs, _ = torch.sort(gathered.reshape(*gathered.shape[:2], -1).sum(-1), dim=-1)
+                gs, _ = torch.sort(
+                    gathered.reshape(*gathered.shape[:2], -1).sum(-1), dim=-1
+                )
                 ms, _ = torch.sort(mk.reshape(*mk.shape[:2], -1).sum(-1), dim=-1)
                 self.assertTrue(torch.allclose(gs, ms, atol=1e-4))
 
@@ -248,6 +306,28 @@ class TestRKVAlgoParity(unittest.TestCase):
             for h in range(cfg["kv_heads"]):
                 kept = set(idx[b, h].tolist())
                 self.assertTrue(window.issubset(kept))
+
+
+class TestFusedValidationMode(unittest.TestCase):
+    """R4: the --rkv-fused-validation policy latched on R1KV construction."""
+
+    def test_off_forces_reference(self):
+        algo = R1KV(budget=64, window_size=8, fused_validation="off")
+        # "off" latches the reference fallback immediately (never uses fused).
+        self.assertIs(algo._fused_redundancy, False)
+
+    def test_default_is_lazy(self):
+        algo = R1KV(budget=64, window_size=8)  # default "first-request"
+        self.assertIsNone(algo._fused_redundancy)
+
+    def test_warmup_is_noop_on_cpu(self):
+        # startup warmup must not crash and must no-op off CUDA (the tests are
+        # CPU-only); the decision stays lazy for the CPU reference path.
+        algo = R1KV(budget=64, window_size=8, fused_validation="startup")
+        algo.warmup_fused_kernel(
+            kv_heads=2, head_dim=16, device="cpu", dtype=torch.float32
+        )
+        self.assertIsNone(algo._fused_redundancy)
 
 
 if __name__ == "__main__":

--- a/SGLang/tests/test_rkv_integration.py
+++ b/SGLang/tests/test_rkv_integration.py
@@ -56,6 +56,7 @@ _integration = _load_by_path(
 RKVConfig = _integration.RKVConfig
 RKVRequestState = _integration.RKVRequestState
 RKVCompressor = _integration.RKVCompressor
+rkv_runtime_support_error = _integration.rkv_runtime_support_error
 
 
 # --------------------------------------------------------------------------- #
@@ -288,12 +289,15 @@ class TestCompactRequest(unittest.TestCase):
         # Physical length shrunk to budget on the request.
         self.assertEqual(req.kv_committed_len, self.budget)
         self.assertEqual(req.kv_allocated_len, self.budget)
-        # Pending physical-length update exposed for the scheduler, drained once.
+        # Pending physical-length update exposed for the scheduler (with the
+        # owning request for identity validation), drained once.
         self.assertEqual(
-            self.comp.pending_length_updates[self.req_pool_idx], self.budget
+            self.comp.pending_length_updates[self.req_pool_idx][0], self.budget
         )
+        self.assertIs(self.comp.pending_length_updates[self.req_pool_idx][1], req)
         drained = self.comp.take_pending_length_updates()
-        self.assertEqual(drained, {self.req_pool_idx: self.budget})
+        self.assertEqual(drained[self.req_pool_idx][0], self.budget)
+        self.assertIs(drained[self.req_pool_idx][1], req)
         self.assertEqual(self.comp.pending_length_updates, {})
 
 
@@ -446,7 +450,7 @@ class TestBatchObserve(unittest.TestCase):
 
         # Only the long request was compacted, shrunk to budget.
         self.assertEqual(
-            self.comp.pending_length_updates.get(self.long_idx), self.budget
+            self.comp.pending_length_updates[self.long_idx][0], self.budget
         )
         self.assertNotIn(self.short_idx, self.comp.pending_length_updates)
         self.assertEqual(len(self.comp._armed), 0)
@@ -655,7 +659,7 @@ class TestMultiRequestAndFailure(unittest.TestCase):
         self.assertEqual(len(alloc.freed), 3)  # one free per request
         self.assertEqual(len(comp._pending_commits), 0)  # queue drained
         for idx, (req, base) in reqs.items():
-            self.assertEqual(comp.pending_length_updates[idx], self.budget)
+            self.assertEqual(comp.pending_length_updates[idx][0], self.budget)
             self.assertEqual(req.kv_committed_len, self.budget)
             # freed = the physical tail [budget, seq_len) of THIS request
             self.assertEqual(
@@ -873,6 +877,284 @@ class TestPerRequestCursor(unittest.TestCase):
         self.assertEqual(wB.tolist(), [200.0, 201.0, 202.0])
         for stale in (100.0, 101.0, 102.0):
             self.assertNotIn(stale, wB.tolist())
+
+
+class _MockTPGroup:
+    """Duck-typed stand-in for a ``GroupCoordinator`` attention-TP group.
+
+    ``all_reduce`` here simulates the collective on a SINGLE process: the
+    default ``fn`` (``x * world_size``) models the physically-correct case where
+    every rank contributed the identical tensor (so the SUM is ``world_size``
+    times one rank's value). A custom ``fn`` lets a test simulate ranks that
+    DISAGREE, to prove the consistency check fires.
+    """
+
+    def __init__(self, world_size, fn=None):
+        self.world_size = world_size
+        self._fn = fn if fn is not None else (lambda x: x * world_size)
+        self.n_all_reduce = 0
+
+    def all_reduce(self, x):
+        self.n_all_reduce += 1
+        return self._fn(x)
+
+
+class TestTensorParallelScore(unittest.TestCase):
+    """TP: the per-token eviction score is SUMMED across the attention-TP group
+    before top-k so every rank keeps the identical tokens (which keeps the
+    replicated ``req_to_token`` consistent). Validated on CPU with a mock group:
+    uniform scaling is top-k invariant, and a divergent reduce raises loudly."""
+
+    def _compressor(self, group):
+        return RKVCompressor(
+            config=RKVConfig(budget=4, window_size=2, buffer_size=4),
+            req_to_token_pool=MockReqToTokenPool(4, 64, torch.device("cpu")),
+            token_to_kv_pool=MockKVPool(
+                1, 64, 1, 4, torch.device("cpu"), torch.float32
+            ),
+            kv_allocator=MockAllocator(),
+            start_layer=0,
+            end_layer=1,
+            device=torch.device("cpu"),
+            q_head_num=1,
+            head_dim=4,
+            q_dtype=torch.float32,
+            attn_tp_group=group,
+        )
+
+    def test_reduce_noop_without_group(self):
+        # tp==1 (no group): the reduce returns the score object unchanged.
+        comp = self._compressor(None)
+        self.assertEqual(comp.attn_tp_size, 1)
+        score = torch.tensor([0.1, 9.0, 0.2, 8.0])
+        self.assertIs(comp._reduce_score_across_tp(score), score)
+
+    def test_reduce_sums_and_preserves_topk(self):
+        # tp==2, ranks identical -> reduced score = 2 x local; top-k unchanged.
+        g = _MockTPGroup(2)
+        comp = self._compressor(g)
+        self.assertEqual(comp.attn_tp_size, 2)
+        score = torch.tensor([0.1, 9.0, 0.2, 8.0])
+        reduced = comp._reduce_score_across_tp(score)
+        self.assertEqual(g.n_all_reduce, 1)
+        self.assertTrue(torch.allclose(reduced, score.float() * 2))
+        # The kept set derived from the summed score must equal the single-rank
+        # kept set: positive uniform scaling cannot change which tokens win.
+        seq_len = 6  # past pool = 4 tokens, trailing window = 2 -> [4, 5]
+        kept_tp = comp._assemble_kept(reduced, seq_len)
+        kept_plain = comp._assemble_kept(score, seq_len)
+        self.assertTrue(torch.equal(kept_tp, kept_plain))
+
+    def test_reduce_casts_to_fp32(self):
+        # Score all-reduce is done in fp32 so ties break identically per rank.
+        g = _MockTPGroup(2)
+        comp = self._compressor(g)
+        score = torch.tensor([0.1, 9.0, 0.2, 8.0], dtype=torch.float16)
+        reduced = comp._reduce_score_across_tp(score)
+        self.assertEqual(reduced.dtype, torch.float32)
+
+    def test_consistency_check_passes_when_ranks_agree(self):
+        # Identical ranks -> SUM == local * world_size -> no raise.
+        g = _MockTPGroup(4)
+        comp = self._compressor(g)
+        comp._check_kept_consistent_across_tp(torch.tensor([1, 3, 4, 5]))
+        self.assertEqual(g.n_all_reduce, 1)
+
+    def test_consistency_check_raises_on_divergence(self):
+        # Ranks disagree: the mocked SUM != local * world_size -> loud failure.
+        g = _MockTPGroup(2, fn=lambda x: x + 1.0)
+        comp = self._compressor(g)
+        with self.assertRaises(RuntimeError):
+            comp._check_kept_consistent_across_tp(torch.tensor([1, 3, 4, 5]))
+
+    def test_consistency_check_noop_without_group(self):
+        # tp==1: no collective is issued at all.
+        comp = self._compressor(None)
+        comp._check_kept_consistent_across_tp(torch.tensor([1, 3, 4, 5]))  # no raise
+
+    def test_consistency_check_fire_schedule(self):
+        # Default (no SGLANG_RKV_TP_CHECK): self-validates only the first few
+        # compactions, then stops issuing the extra collective.
+        g = _MockTPGroup(2)
+        comp = self._compressor(g)
+        budget = comp._tp_check_remaining
+        self.assertGreater(budget, 0)
+        for _ in range(budget):
+            comp._check_kept_consistent_across_tp(torch.tensor([1, 3, 4, 5]))
+        fired = g.n_all_reduce
+        self.assertEqual(fired, budget)
+        # Past the startup budget the check no longer issues a collective.
+        for _ in range(3):
+            comp._check_kept_consistent_across_tp(torch.tensor([1, 3, 4, 5]))
+        self.assertEqual(g.n_all_reduce, fired)
+
+
+class TestPendingUpdateLifecycle(unittest.TestCase):
+    """Issue 1 regressions: no pending physical-length update may survive a
+    finish/retract and be applied to the next request that reuses the slot."""
+
+    def _build(self):
+        device = torch.device("cpu")
+        r2t = MockReqToTokenPool(8, 64, device)
+        kv = MockKVPool(2, 128, 2, 4, device, torch.float32)
+        comp = RKVCompressor(
+            config=RKVConfig(budget=4, window_size=2, buffer_size=4),
+            req_to_token_pool=r2t,
+            token_to_kv_pool=kv,
+            kv_allocator=MockAllocator(),
+            start_layer=0,
+            end_layer=2,
+            device=device,
+            q_head_num=2,
+            head_dim=4,
+            q_dtype=torch.float32,
+        )
+        return comp, r2t
+
+    def _compact(self, comp, r2t, idx):
+        """Register a request at ``idx``, prepare + commit one compaction (which
+        publishes a pending length update), and return the request."""
+        req = _MockReq(origin_len=20, output_len=100, req_pool_idx=idx)
+        comp.on_request_begin(req)
+        r2t.req_to_token[idx, :6] = torch.arange(10, 16, dtype=torch.int32)
+        comp._pending_commits.append(
+            comp._prepare_compaction(comp.states[idx], 6, torch.tensor([0, 2, 4, 5]))
+        )
+        comp.commit_compactions()
+        return req
+
+    def test_pending_update_carries_owner_identity(self):
+        comp, r2t = self._build()
+        req = self._compact(comp, r2t, 1)
+        new_len, owner = comp.pending_length_updates[1]
+        self.assertEqual(new_len, 4)
+        self.assertIs(owner, req)  # identity attached for scheduler validation
+
+    def test_finish_clears_pending_update(self):
+        comp, r2t = self._build()
+        req = self._compact(comp, r2t, 1)
+        self.assertIn(1, comp.pending_length_updates)  # commit published it
+        comp.on_request_end(req)  # compact + finish on the same step
+        self.assertNotIn(1, comp.pending_length_updates)  # finish cleared it
+        self.assertNotIn(1, comp.states)
+
+    def test_retract_clears_pending_update(self):
+        comp, r2t = self._build()
+        req = self._compact(comp, r2t, 1)
+        self.assertIn(1, comp.pending_length_updates)
+        comp.on_request_retract(req)
+        self.assertNotIn(1, comp.pending_length_updates)
+        self.assertNotIn(1, comp.states)
+
+    def test_slot_reuse_after_finish_leaves_no_stale_update(self):
+        # A compacts at idx 1 and finishes as the last request; the running
+        # batch goes empty so the scheduler never drained the update. B then
+        # reuses idx 1. The drain must not carry A's stale budget onto B.
+        comp, r2t = self._build()
+        req_a = self._compact(comp, r2t, 1)
+        comp.on_request_end(req_a)
+        req_b = _MockReq(origin_len=7, output_len=0, req_pool_idx=1)
+        comp.on_request_begin(req_b)  # B reuses slot 1
+        self.assertEqual(comp.take_pending_length_updates(), {})
+
+    def test_stale_update_owner_mismatches_reused_request(self):
+        # If a clear were ever missed, the update's owner is still request A, not
+        # the request B that reuses the slot -- so the scheduler identity guard
+        # (owner is req) skips it. Pin that the owner is NOT the reused request.
+        comp, r2t = self._build()
+        req_a = self._compact(comp, r2t, 1)
+        _, owner = comp.pending_length_updates[1]
+        req_b = _MockReq(origin_len=7, output_len=0, req_pool_idx=1)
+        comp.on_request_begin(req_b)
+        self.assertIs(owner, req_a)
+        self.assertIsNot(owner, req_b)
+
+
+class TestRuntimeSupportGate(unittest.TestCase):
+    """Issue 2: the late (post-resolution) gate hard-fails any runtime the R-KV
+    observation/compaction hooks are not wired for."""
+
+    def _reason(self, **over):
+        kw = dict(
+            mode="decode",
+            prefill_backend="flashinfer",
+            decode_backend="flashinfer",
+            use_mla=False,
+            is_hybrid_swa=False,
+            spec_enabled=False,
+            page_size=1,
+        )
+        kw.update(over)
+        return rkv_runtime_support_error(**kw)
+
+    def test_flashinfer_mha_supported(self):
+        self.assertIsNone(self._reason())
+        self.assertIsNone(self._reason(mode="prefill", page_size=None))
+
+    def test_non_flashinfer_backend_rejected(self):
+        self.assertIsNotNone(self._reason(decode_backend="fa3"))
+        self.assertIsNotNone(self._reason(prefill_backend="triton"))
+        self.assertIsNotNone(self._reason(decode_backend=None))
+
+    def test_mla_rejected(self):
+        self.assertIsNotNone(self._reason(use_mla=True))
+
+    def test_hybrid_swa_rejected(self):
+        self.assertIsNotNone(self._reason(is_hybrid_swa=True))
+
+    def test_speculative_rejected(self):
+        self.assertIsNotNone(self._reason(spec_enabled=True))
+
+    def test_page_size_gt_one_rejected(self):
+        self.assertIsNotNone(self._reason(page_size=16))
+        self.assertIsNone(self._reason(page_size=1))
+        self.assertIsNone(self._reason(page_size=None))
+
+
+class TestServingConfigValidation(unittest.TestCase):
+    """Issue 3: config-level guards + serving restricted to the bounded path."""
+
+    def _serve(self, **cfg):
+        return RKVCompressor(
+            config=RKVConfig(**cfg),
+            req_to_token_pool=MockReqToTokenPool(4, 128, torch.device("cpu")),
+            token_to_kv_pool=MockKVPool(
+                2, 128, 2, 4, torch.device("cpu"), torch.float32
+            ),
+            kv_allocator=MockAllocator(),
+            start_layer=0,
+            end_layer=2,
+            device=torch.device("cpu"),
+            q_head_num=2,
+            head_dim=4,
+            q_dtype=torch.float32,
+        )
+
+    def test_even_kernel_size_rejected(self):
+        with self.assertRaises(ValueError):
+            RKVConfig(budget=64, window_size=8, kernel_size=8)
+
+    def test_nonpositive_window_rejected(self):
+        with self.assertRaises(ValueError):
+            RKVConfig(budget=64, window_size=0)
+
+    def test_unknown_retain_direction_rejected(self):
+        with self.assertRaises(ValueError):
+            RKVConfig(budget=64, window_size=8, retain_direction="middle")
+
+    def test_odd_kernel_and_known_retain_accepted(self):
+        RKVConfig(budget=64, window_size=8, kernel_size=7, retain_direction="first")
+
+    def test_serving_rejects_non_last_retain(self):
+        # The algorithm accepts other directions offline, but the SERVED
+        # compressor is restricted to the memory-bounded retain_direction="last"
+        # path (others build an unbounded kv_heads x n x n matrix).
+        with self.assertRaises(ValueError):
+            self._serve(budget=64, window_size=8, retain_direction="first")
+
+    def test_serving_accepts_last_retain(self):
+        comp = self._serve(budget=64, window_size=8, retain_direction="last")
+        self.assertEqual(comp.config.retain_direction, "last")
 
 
 if __name__ == "__main__":

--- a/SGLang/tests/test_rkv_integration.py
+++ b/SGLang/tests/test_rkv_integration.py
@@ -8,7 +8,7 @@ is satisfied by pre-registering the algo module under its real dotted name in
 
 Run directly::
 
-    python tests/test_rkv_integration.py
+    python test/srt/mem_cache/test_rkv_integration.py
 
 or under a test runner (unittest / pytest).
 """
@@ -48,9 +48,7 @@ for _pkg in (
         _placeholder.__path__ = []  # mark as package
         sys.modules[_pkg] = _placeholder
 
-_load_by_path(
-    "sglang.srt.mem_cache.rkv.algo", os.path.join(_RKV_DIR, "algo.py")
-)
+_load_by_path("sglang.srt.mem_cache.rkv.algo", os.path.join(_RKV_DIR, "algo.py"))
 _integration = _load_by_path(
     "sglang.srt.mem_cache.rkv.integration", os.path.join(_RKV_DIR, "integration.py")
 )
@@ -110,6 +108,13 @@ class _MockReq:
         self.req_pool_idx = req_pool_idx
 
 
+def _prepare_and_commit(comp, state, seq_len, kept):
+    """Two-phase compaction convenience for tests: prepare (relocate K/V) then
+    commit (free tail + bookkeeping), mirroring maybe_compact + the scheduler's
+    commit_compactions()."""
+    comp._commit_compaction(comp._prepare_compaction(state, seq_len, kept))
+
+
 # --------------------------------------------------------------------------- #
 # Tests                                                                       #
 # --------------------------------------------------------------------------- #
@@ -119,11 +124,16 @@ class TestAssembleKept(unittest.TestCase):
         return RKVCompressor(
             config=cfg,
             req_to_token_pool=MockReqToTokenPool(1, 64, torch.device("cpu")),
-            token_to_kv_pool=MockKVPool(1, 64, 1, 4, torch.device("cpu"), torch.float32),
+            token_to_kv_pool=MockKVPool(
+                1, 64, 1, 4, torch.device("cpu"), torch.float32
+            ),
             kv_allocator=MockAllocator(),
             start_layer=0,
             end_layer=1,
             device=torch.device("cpu"),
+            q_head_num=1,
+            head_dim=4,
+            q_dtype=torch.float32,
         )
 
     def test_kept_is_top_past_plus_window_sorted(self):
@@ -179,6 +189,9 @@ class TestCompactRequest(unittest.TestCase):
             start_layer=0,
             end_layer=self.num_layers,
             device=self.device,
+            q_head_num=self.head_num,
+            head_dim=self.head_dim,
+            q_dtype=self.dtype,
         )
 
         # Physical slots this request occupies, in temporal order.
@@ -199,31 +212,27 @@ class TestCompactRequest(unittest.TestCase):
                 kb[s] = pattern
                 vb[s] = pattern + 0.5  # distinguish V from K
 
-        self.state = RKVRequestState(
-            req_pool_idx=self.req_pool_idx,
-            num_layers=self.num_layers,
-            window_size=self.window,
-            device=self.device,
-            dtype=self.dtype,
-        )
+        self.state = RKVRequestState(req_pool_idx=self.req_pool_idx)
+        # Register the state so the commit-phase identity guard resolves it
+        # (the real flow registers via on_request_begin).
+        self.comp.states[self.req_pool_idx] = self.state
 
     def test_relocation_free_and_rewrite(self):
         # Keep past tokens {0, 2} plus the window {4, 5}. Ascending.
         kept_local = torch.tensor([0, 2, 4, 5])
-        src = self.slots[kept_local]              # [10, 12, 14, 15]
-        dst = self.slots[: self.budget]           # [10, 11, 12, 13]
+        src = self.slots[kept_local]  # [10, 12, 14, 15]
+        dst = self.slots[: self.budget]  # [10, 11, 12, 13]
 
         # Snapshot the kept slots' KV BEFORE compaction (from src slots).
         expected_k = [
-            self.kv_pool.get_key_buffer(l)[src].clone()
-            for l in range(self.num_layers)
+            self.kv_pool.get_key_buffer(l)[src].clone() for l in range(self.num_layers)
         ]
         expected_v = [
             self.kv_pool.get_value_buffer(l)[src].clone()
             for l in range(self.num_layers)
         ]
 
-        self.comp._compact_request(self.state, self.seq_len, kept_local)
+        _prepare_and_commit(self.comp, self.state, self.seq_len, kept_local)
 
         # (1) Front `budget` dst slots now hold the kept KV, in temporal order.
         for l in range(self.num_layers):
@@ -253,15 +262,14 @@ class TestCompactRequest(unittest.TestCase):
         # Keep tokens whose src slots overlap dst heavily to stress the
         # clone-before-write path: keep {1, 3} + window {4, 5}.
         kept_local = torch.tensor([1, 3, 4, 5])
-        src = self.slots[kept_local]              # [11, 13, 14, 15]
-        dst = self.slots[: self.budget]           # [10, 11, 12, 13]  (overlaps src)
+        src = self.slots[kept_local]  # [11, 13, 14, 15]
+        dst = self.slots[: self.budget]  # [10, 11, 12, 13]  (overlaps src)
 
         expected_k = [
-            self.kv_pool.get_key_buffer(l)[src].clone()
-            for l in range(self.num_layers)
+            self.kv_pool.get_key_buffer(l)[src].clone() for l in range(self.num_layers)
         ]
 
-        self.comp._compact_request(self.state, self.seq_len, kept_local)
+        _prepare_and_commit(self.comp, self.state, self.seq_len, kept_local)
 
         for l in range(self.num_layers):
             self.assertTrue(
@@ -275,7 +283,7 @@ class TestCompactRequest(unittest.TestCase):
         self.state.req = req
         kept_local = torch.tensor([0, 2, 4, 5])
 
-        self.comp._compact_request(self.state, self.seq_len, kept_local)
+        _prepare_and_commit(self.comp, self.state, self.seq_len, kept_local)
 
         # Physical length shrunk to budget on the request.
         self.assertEqual(req.kv_committed_len, self.budget)
@@ -334,6 +342,9 @@ class TestBatchObserve(unittest.TestCase):
             start_layer=0,
             end_layer=self.num_layers,
             device=self.device,
+            q_head_num=self.head_num,
+            head_dim=self.head_dim,
+            q_dtype=self.dtype,
         )
 
         # req A (idx 1): long enough to be eligible; req B (idx 2): short.
@@ -356,8 +367,11 @@ class TestBatchObserve(unittest.TestCase):
 
     def _forward_batch(self):
         return types.SimpleNamespace(
+            # req_pool_indices is int64 in the real runtime (schedule_batch and
+            # every cuda-graph runner allocate it as torch.int64); match that so
+            # the in-graph collect_decode_query index arithmetic is a long index.
             req_pool_indices=torch.tensor(
-                [self.long_idx, self.short_idx], dtype=torch.int32
+                [self.long_idx, self.short_idx], dtype=torch.int64
             ),
             seq_lens=torch.tensor([self.long_len, self.short_len], dtype=torch.int32),
             seq_lens_cpu=torch.tensor(
@@ -370,42 +384,65 @@ class TestBatchObserve(unittest.TestCase):
         torch.manual_seed(0)
         fb = self._forward_batch()
 
-        # Feed buffer_size decode steps; each step touches all layers.
+        # Feed buffer_size decode steps; each step refreshes the write slot and
+        # collects every layer's query into the in-graph rolling buffer.
         for _ in range(self.buffer_size):
+            self.comp.begin_decode_step(fb)
             for layer_idx in range(self.num_layers):
                 layer = types.SimpleNamespace(layer_id=layer_idx)
                 q = torch.randn(2, self.head_num, self.head_dim)
-                self.comp.observe_decode_layer(q, None, None, layer, fb)
+                self.comp.collect_decode_query(q, layer, fb)
 
         # Long request armed; short request did not.
         self.assertIn(self.long_idx, self.comp._armed)
         self.assertNotIn(self.short_idx, self.comp._armed)
 
-        # begin_step advanced both requests once per step (per-request state).
+        # begin_decode_step advanced only the eligible (long) request; the short
+        # request's seq_len stays below min_seq_len so its clock never starts.
         self.assertEqual(
             self.comp.states[self.long_idx].steps_since_compact, self.buffer_size
         )
-        self.assertEqual(
-            self.comp.states[self.short_idx].steps_since_compact, self.buffer_size
-        )
+        self.assertEqual(self.comp.states[self.short_idx].steps_since_compact, 0)
 
-        # Armed request accumulated a per-past-token score of the right shape.
-        accum = self.comp.states[self.long_idx].score_accum
-        self.assertIsNotNone(accum)
-        self.assertEqual(accum.shape, (self.long_len - self.window,))
-        self.assertIsNone(self.comp.states[self.short_idx].score_accum)
+        # Scoring reads the observation window from the rolling buffer, exactly
+        # as maybe_compact does. Batched scoring must match the per-layer
+        # reference (the invariant the A/B gate relies on).
+        long_state = self.comp.states[self.long_idx]
+        long_state.window_q = self.comp._read_window_rolling(self.long_idx)
+        ref = self.comp._reference_scores(long_state, self.long_len)
+        bat = self.comp._batched_scores(long_state, self.long_len)
+        self.assertEqual(ref.shape, (self.long_len - self.window,))
+        self.assertEqual(bat.shape, (self.long_len - self.window,))
+        self.assertTrue(torch.allclose(ref, bat, atol=1e-4))
+
+    def test_eager_gating_schedule(self):
+        # begin_decode_step forces EAGER only on the compaction step now: the
+        # window queries are collected in-graph, so the observation-window steps
+        # replay the captured graph. window=2, buffer=3 -> compaction (and the
+        # only eager step) at steps_since_compact==3.
+        self._build()
+        fb = self._forward_batch()
+        needs = [self.comp.begin_decode_step(fb) for _ in range(self.buffer_size)]
+        self.assertEqual(needs, [False, False, True])
+        # Last step is the compaction step: the long request armed.
+        self.assertIn(self.long_idx, self.comp._armed)
+        # The short request (below min_seq_len) never arms or forces eager.
+        self.assertNotIn(self.short_idx, self.comp._armed)
+        self.assertEqual(self.comp.states[self.short_idx].steps_since_compact, 0)
 
     def test_maybe_compact_uses_per_request_seq_len(self):
         self._build()
         torch.manual_seed(1)
         fb = self._forward_batch()
         for _ in range(self.buffer_size):
+            self.comp.begin_decode_step(fb)
             for layer_idx in range(self.num_layers):
                 layer = types.SimpleNamespace(layer_id=layer_idx)
                 q = torch.randn(2, self.head_num, self.head_dim)
-                self.comp.observe_decode_layer(q, None, None, layer, fb)
+                self.comp.collect_decode_query(q, layer, fb)
 
         self.comp.maybe_compact(fb)
+        self.comp.commit_compactions()
 
         # Only the long request was compacted, shrunk to budget.
         self.assertEqual(
@@ -427,6 +464,9 @@ class TestLifecycle(unittest.TestCase):
             start_layer=0,
             end_layer=2,
             device=torch.device("cpu"),
+            q_head_num=2,
+            head_dim=4,
+            q_dtype=torch.float32,
         )
 
     def test_begin_registers_and_end_clears_state(self):
@@ -447,6 +487,392 @@ class TestLifecycle(unittest.TestCase):
         comp.on_request_end(req)
         comp.on_request_end(req)  # double end -> must not raise
         self.assertEqual(len(comp.states), 0)
+
+
+class TestCompactInvariants(unittest.TestCase):
+    """A bad kept set must fail fast BEFORE any KV buffer is mutated or freed,
+    so a scoring/selection bug can never leave a request half-relocated or
+    double-free a physical slot (crash-consistency)."""
+
+    def setUp(self):
+        self.device = torch.device("cpu")
+        self.num_layers = 2
+        self.head_num = 2
+        self.head_dim = 4
+        self.budget = 4
+        self.window = 2
+        self.seq_len = 6
+        self.req_pool_idx = 1
+        self.num_slots = 32
+
+        self.r2t_pool = MockReqToTokenPool(4, 64, self.device)
+        self.kv_pool = MockKVPool(
+            self.num_layers,
+            self.num_slots,
+            self.head_num,
+            self.head_dim,
+            self.device,
+            torch.float32,
+        )
+        self.alloc = MockAllocator()
+        self.comp = RKVCompressor(
+            config=RKVConfig(
+                budget=self.budget, window_size=self.window, buffer_size=4
+            ),
+            req_to_token_pool=self.r2t_pool,
+            token_to_kv_pool=self.kv_pool,
+            kv_allocator=self.alloc,
+            start_layer=0,
+            end_layer=self.num_layers,
+            device=self.device,
+            q_head_num=self.head_num,
+            head_dim=self.head_dim,
+            q_dtype=torch.float32,
+        )
+        self.slots = torch.tensor([10, 11, 12, 13, 14, 15], dtype=torch.int32)
+        self.r2t_pool.req_to_token[self.req_pool_idx, : self.seq_len] = self.slots
+        self._k_snapshot = [
+            self.kv_pool.get_key_buffer(l).clone() for l in range(self.num_layers)
+        ]
+        self.state = RKVRequestState(req_pool_idx=self.req_pool_idx)
+        # Register the state so the commit-phase identity guard resolves it.
+        self.comp.states[self.req_pool_idx] = self.state
+
+    def _assert_no_mutation(self):
+        # No slot was freed and no KV buffer changed.
+        self.assertEqual(len(self.alloc.freed), 0)
+        for l in range(self.num_layers):
+            self.assertTrue(
+                torch.equal(self.kv_pool.get_key_buffer(l), self._k_snapshot[l])
+            )
+
+    def test_wrong_length_raises(self):
+        with self.assertRaises(RuntimeError):
+            self.comp._prepare_compaction(
+                self.state, self.seq_len, torch.tensor([0, 2, 5])  # 3 != budget 4
+            )
+        self._assert_no_mutation()
+
+    def test_non_ascending_raises(self):
+        with self.assertRaises(RuntimeError):
+            # descending / unsorted kept indices
+            self.comp._prepare_compaction(
+                self.state, self.seq_len, torch.tensor([3, 1, 4, 5])
+            )
+        self._assert_no_mutation()
+
+    def test_duplicate_index_raises(self):
+        with self.assertRaises(RuntimeError):
+            # 4 appears twice -> not strictly ascending AND duplicate slot
+            self.comp._prepare_compaction(
+                self.state, self.seq_len, torch.tensor([1, 4, 4, 5])
+            )
+        self._assert_no_mutation()
+
+    def test_out_of_range_raises(self):
+        with self.assertRaises(RuntimeError):
+            # index 6 >= seq_len 6
+            self.comp._prepare_compaction(
+                self.state, self.seq_len, torch.tensor([0, 2, 4, 6])
+            )
+        self._assert_no_mutation()
+
+    def test_duplicate_physical_slot_raises(self):
+        # Corrupt req_to_token: slot 10 appears twice. A valid ascending kept set
+        # keeps only ONE copy, so src is unique, but the freed tail would then
+        # contain slot 10 which req_to_token[:budget] still references (a
+        # use-after-free). The full-table uniqueness guard must catch this before
+        # any KV write or free.
+        self.r2t_pool.req_to_token[self.req_pool_idx, : self.seq_len] = torch.tensor(
+            [10, 11, 12, 10, 14, 15], dtype=torch.int32
+        )
+        with self.assertRaises(RuntimeError):
+            self.comp._prepare_compaction(
+                self.state, self.seq_len, torch.tensor([0, 1, 4, 5])
+            )
+        self._assert_no_mutation()
+
+    def test_valid_kept_still_compacts(self):
+        # Sanity: a valid ascending, in-range, budget-sized kept set proceeds.
+        _prepare_and_commit(
+            self.comp, self.state, self.seq_len, torch.tensor([0, 2, 4, 5])
+        )
+        self.assertEqual(len(self.alloc.freed), 1)
+
+
+class TestMultiRequestAndFailure(unittest.TestCase):
+    """Two-phase compaction across several requests, and its failure semantics."""
+
+    def _build(self, budget=4, window=2, seq_len=6, allocator=None):
+        device = torch.device("cpu")
+        self.num_layers, self.head_num, self.head_dim = 2, 2, 4
+        self.budget, self.window, self.seq_len = budget, window, seq_len
+        r2t = MockReqToTokenPool(8, 64, device)
+        kv = MockKVPool(
+            self.num_layers, 128, self.head_num, self.head_dim, device, torch.float32
+        )
+        alloc = allocator if allocator is not None else MockAllocator()
+        comp = RKVCompressor(
+            config=RKVConfig(budget=budget, window_size=window, buffer_size=4),
+            req_to_token_pool=r2t,
+            token_to_kv_pool=kv,
+            kv_allocator=alloc,
+            start_layer=0,
+            end_layer=self.num_layers,
+            device=device,
+            q_head_num=self.head_num,
+            head_dim=self.head_dim,
+            q_dtype=torch.float32,
+        )
+        return comp, r2t, alloc
+
+    def _register(self, comp, r2t, idx, i):
+        req = _MockReq(origin_len=20, output_len=100, req_pool_idx=idx)
+        comp.on_request_begin(req)
+        base = 10 + i * 10  # distinct physical slots per request
+        r2t.req_to_token[idx, : self.seq_len] = torch.arange(
+            base, base + self.seq_len, dtype=torch.int32
+        )
+        return req, base
+
+    def test_multiple_requests_same_step(self):
+        # 3 requests armed the same forward: all prepare, all commit, freed
+        # counts + pending lengths correct, queue drained.
+        comp, r2t, alloc = self._build()
+        reqs = {}
+        for i, idx in enumerate((1, 2, 3)):
+            req, base = self._register(comp, r2t, idx, i)
+            reqs[idx] = (req, base)
+            comp._pending_commits.append(
+                comp._prepare_compaction(
+                    comp.states[idx], self.seq_len, torch.tensor([0, 2, 4, 5])
+                )
+            )
+        self.assertEqual(len(comp._pending_commits), 3)
+
+        comp.commit_compactions()
+
+        self.assertEqual(len(alloc.freed), 3)  # one free per request
+        self.assertEqual(len(comp._pending_commits), 0)  # queue drained
+        for idx, (req, base) in reqs.items():
+            self.assertEqual(comp.pending_length_updates[idx], self.budget)
+            self.assertEqual(req.kv_committed_len, self.budget)
+            # freed = the physical tail [budget, seq_len) of THIS request
+            self.assertEqual(
+                sorted(
+                    s for f in alloc.freed for s in f.tolist() if base <= s < base + 10
+                ),
+                [base + 4, base + 5],
+            )
+
+    def test_compact_then_finish_no_double_free(self):
+        # After the commit frees the tail, a same-step finish would release the
+        # shrunk head (req_to_token[:budget]). The two freed sets must be disjoint.
+        comp, r2t, alloc = self._build()
+        req, base = self._register(comp, r2t, 1, 0)
+        comp._pending_commits.append(
+            comp._prepare_compaction(
+                comp.states[1], self.seq_len, torch.tensor([0, 2, 4, 5])
+            )
+        )
+        comp.commit_compactions()
+
+        tail_freed = set(alloc.freed[0].tolist())  # {base+4, base+5}
+        head = r2t.req_to_token[1, : req.kv_committed_len].tolist()  # retained head
+        self.assertTrue(
+            tail_freed.isdisjoint(set(head)), "tail/head overlap => double free"
+        )
+        # req_to_token tail was cleared to 0.
+        self.assertEqual(
+            r2t.req_to_token[1, self.budget : self.seq_len].tolist(), [0, 0]
+        )
+
+    def test_commit_failure_does_not_recommit(self):
+        # A mid-drain allocator failure must not re-commit the already-freed plan
+        # on a retry: commit_compactions drains _pending_commits UP FRONT.
+        class RaisingAllocator:
+            def __init__(self, raise_on):
+                self.freed = []
+                self._n = 0
+                self._raise_on = raise_on
+
+            def free(self, idx):
+                self._n += 1
+                if self._n == self._raise_on:
+                    raise RuntimeError("simulated allocator failure")
+                self.freed.append(idx.clone())
+
+        comp, r2t, alloc = self._build(allocator=RaisingAllocator(raise_on=2))
+        for i, idx in enumerate((1, 2)):
+            self._register(comp, r2t, idx, i)
+            comp._pending_commits.append(
+                comp._prepare_compaction(
+                    comp.states[idx], self.seq_len, torch.tensor([0, 2, 4, 5])
+                )
+            )
+        with self.assertRaises(RuntimeError):
+            comp.commit_compactions()
+        # First plan committed (freed once); queue drained so a retry is a no-op
+        # and cannot re-free the first plan's slots.
+        self.assertEqual(len(alloc.freed), 1)
+        self.assertEqual(len(comp._pending_commits), 0)
+        comp.commit_compactions()  # no-op
+        self.assertEqual(len(alloc.freed), 1)
+
+    def test_stale_plan_identity_raises(self):
+        # A plan whose request slot was released/reused before commit is an
+        # unrecoverable invariant break -> RuntimeError (not a silent skip).
+        comp, r2t, alloc = self._build()
+        req, _ = self._register(comp, r2t, 1, 0)
+        comp._pending_commits.append(
+            comp._prepare_compaction(
+                comp.states[1], self.seq_len, torch.tensor([0, 2, 4, 5])
+            )
+        )
+        comp.on_request_end(req)  # slot released -> state dropped
+        with self.assertRaises(RuntimeError):
+            comp.commit_compactions()
+
+
+class TestRollingQSizeContract(unittest.TestCase):
+    """Pin the rolling_q allocation shape/bytes that the KV-pool reservation
+    (ModelRunner._reserve_rkv_decode_aux_bytes) is computed from. If the buffer
+    layout changes, the reservation formula must change with it — this test
+    fails loudly to force that."""
+
+    def test_bytes_match_reservation_formula(self):
+        num_reqs, num_layers, window = 5, 3, 8
+        q_heads, head_dim = 7, 16
+        dtype = torch.bfloat16
+        comp = RKVCompressor(
+            config=RKVConfig(budget=64, window_size=window),
+            req_to_token_pool=MockReqToTokenPool(num_reqs, 128, torch.device("cpu")),
+            token_to_kv_pool=MockKVPool(
+                num_layers, 128, 2, head_dim, torch.device("cpu"), dtype
+            ),
+            kv_allocator=MockAllocator(),
+            start_layer=0,
+            end_layer=num_layers,
+            device=torch.device("cpu"),
+            q_head_num=q_heads,
+            head_dim=head_dim,
+            q_dtype=dtype,
+        )
+        # Rows == req_to_token rows == num_reqs + 1 (reserved padding row).
+        expected_rows = num_reqs + 1
+        self.assertEqual(comp.rolling_q.shape[2], expected_rows)
+        actual_bytes = comp.rolling_q.numel() * comp.rolling_q.element_size()
+        # Same product the mixin helper computes.
+        formula_bytes = (
+            num_layers
+            * window
+            * expected_rows
+            * q_heads
+            * head_dim
+            * torch.finfo(dtype).bits
+            // 8
+        )
+        self.assertEqual(actual_bytes, formula_bytes)
+
+
+class TestPerRequestCursor(unittest.TestCase):
+    """R3: a per-request write cursor keeps a request's observation window
+    correctly ordered even when it SKIPS decode steps. The old single global
+    cursor advanced on every step regardless of batch membership, so a skipped
+    step left a phantom (unwritten) slot BETWEEN a request's real queries."""
+
+    def _build(self, window=3):
+        device = torch.device("cpu")
+        comp = RKVCompressor(
+            config=RKVConfig(
+                budget=window + 1, window_size=window, buffer_size=window + 1
+            ),
+            req_to_token_pool=MockReqToTokenPool(4, 64, device),
+            token_to_kv_pool=MockKVPool(1, 64, 1, 1, device, torch.float32),
+            kv_allocator=MockAllocator(),
+            start_layer=0,
+            end_layer=1,
+            device=device,
+            q_head_num=1,
+            head_dim=1,
+            q_dtype=torch.float32,
+        )
+        return comp
+
+    @staticmethod
+    def _fb(indices):
+        idx = torch.tensor(indices, dtype=torch.int64)
+        # seq_lens below min_seq_len so nothing arms; only exercise the cursor.
+        sl = torch.ones(len(indices), dtype=torch.int32)
+        return types.SimpleNamespace(req_pool_indices=idx, seq_lens=sl, seq_lens_cpu=sl)
+
+    def _step(self, comp, indices, tags):
+        fb = self._fb(indices)
+        comp.begin_decode_step(fb)
+        q = torch.tensor(tags, dtype=torch.float32).view(-1, 1, 1)
+        comp.collect_decode_query(q, types.SimpleNamespace(layer_id=0), fb)
+
+    def test_skipped_step_keeps_window_order(self):
+        comp = self._build(window=3)
+        A, B = 1, 2
+        comp.on_request_begin(_MockReq(1, 0, req_pool_idx=A))
+        comp.on_request_begin(_MockReq(1, 0, req_pool_idx=B))
+
+        # B participates in steps 1 and 3 but is ABSENT from step 2.
+        self._step(comp, [A, B], [10.0, 100.0])  # qB1 = 100
+        self._step(comp, [A], [11.0])  # B absent (skipped step)
+        self._step(comp, [A, B], [12.0, 200.0])  # qB2 = 200
+
+        wB = comp._read_window_rolling(B)[0, :, 0, 0]  # (window,) temporal order
+        # B's two real queries must be the most recent two, IN ORDER, with the
+        # unwritten slot pushed to the oldest end (not wedged between them).
+        self.assertEqual(wB[-1].item(), 200.0)
+        self.assertEqual(wB[-2].item(), 100.0)
+        # No A query leaked into B's window.
+        self.assertNotIn(11.0, wB.tolist())
+        self.assertNotIn(12.0, wB.tolist())
+
+        # A participated every step: newest-two in order = [11, 12].
+        wA = comp._read_window_rolling(A)[0, :, 0, 0]
+        self.assertEqual(wA[-1].item(), 12.0)
+        self.assertEqual(wA[-2].item(), 11.0)
+
+    def test_reused_slot_resets_cursor(self):
+        comp = self._build(window=3)
+        A = 1
+        comp.on_request_begin(_MockReq(1, 0, req_pool_idx=A))
+        self._step(comp, [A], [1.0])
+        self._step(comp, [A], [2.0])
+        self.assertEqual(int(comp.step_count_of_req[A].item()), 2)
+        # A finishes; a new request reuses the same slot -> counter resets.
+        comp.on_request_end(_MockReq(1, 0, req_pool_idx=A))
+        comp.on_request_begin(_MockReq(1, 0, req_pool_idx=A))
+        self.assertEqual(int(comp.step_count_of_req[A].item()), 0)
+
+    def test_reused_slot_window_has_no_stale_q(self):
+        # Request A fills its whole observation window, finishes, then request B
+        # reuses the SAME req_pool_idx. After B has run window_size steps its
+        # window must contain ONLY B's queries in order (no stale A data) — the
+        # invariant buffer_size >= window_size relies on, verified directly.
+        window = 3
+        comp = self._build(window=window)
+        X = 1  # shared req_pool_idx
+        comp.on_request_begin(_MockReq(1, 0, req_pool_idx=X))
+        for tag in (100.0, 101.0, 102.0):  # fill A's window
+            self._step(comp, [X], [tag])
+        wA = comp._read_window_rolling(X)[0, :, 0, 0]
+        self.assertEqual(wA.tolist(), [100.0, 101.0, 102.0])
+
+        comp.on_request_end(_MockReq(1, 0, req_pool_idx=X))
+        comp.on_request_begin(_MockReq(1, 0, req_pool_idx=X))  # B reuses slot X
+        for tag in (200.0, 201.0, 202.0):  # B's window_size fresh writes
+            self._step(comp, [X], [tag])
+
+        wB = comp._read_window_rolling(X)[0, :, 0, 0]
+        # Only B's queries, in temporal order; no A residue.
+        self.assertEqual(wB.tolist(), [200.0, 201.0, 202.0])
+        for stale in (100.0, 101.0, 102.0):
+            self.assertNotIn(stale, wB.tolist())
 
 
 if __name__ == "__main__":

--- a/SGLang/tests/test_rkv_integration.py
+++ b/SGLang/tests/test_rkv_integration.py
@@ -1110,6 +1110,28 @@ class TestRuntimeSupportGate(unittest.TestCase):
         self.assertIsNone(self._reason(page_size=1))
         self.assertIsNone(self._reason(page_size=None))
 
+    def test_fp8_e4m3_kv_cache_rejected(self):
+        reason = self._reason(kv_cache_dtype=torch.float8_e4m3fn)
+        self.assertIsNotNone(reason)
+        self.assertIn("fp8_e4m3", reason)
+
+    def test_fp8_e5m2_kv_cache_rejected(self):
+        self.assertIsNotNone(self._reason(kv_cache_dtype=torch.float8_e5m2))
+
+    def test_fp4_e2m1_kv_cache_rejected(self):
+        # torch.float4_e2m1fn_x2 exists only on newer torch builds.
+        fp4 = getattr(torch, "float4_e2m1fn_x2", None)
+        if fp4 is None:
+            self.skipTest("torch build has no float4_e2m1fn_x2")
+        self.assertIsNotNone(self._reason(kv_cache_dtype=fp4))
+
+    def test_unquantized_kv_cache_dtypes_supported(self):
+        for dt in (torch.float16, torch.bfloat16, torch.float32):
+            self.assertIsNone(self._reason(kv_cache_dtype=dt), msg=str(dt))
+
+    def test_kv_cache_dtype_none_skips_check(self):
+        self.assertIsNone(self._reason(kv_cache_dtype=None))
+
 
 class TestServingConfigValidation(unittest.TestCase):
     """Issue 3: config-level guards + serving restricted to the bounded path."""

--- a/SGLang/tests/test_rkv_prefill.py
+++ b/SGLang/tests/test_rkv_prefill.py
@@ -1,0 +1,232 @@
+"""Tests for R-KV **prefill** compression: tiled-similarity parity + A/B diff-test.
+
+Two things are checked without a GPU or the serving stack:
+
+1. **Parity** — :func:`cal_similarity_tiled` (route A's ``O(n)``-memory redundancy)
+   reproduces the reference ``algo.cal_similarity`` exactly for
+   ``retain_direction='last'``, and route A's one-shot selection matches a
+   direct full-matrix R-KV selection.
+
+2. **Diff-test invariants** — route A (one-shot oracle) and route B (buffered)
+   both return ``budget`` ascending indices that include the trailing window,
+   and the *premature-eviction* metric (tokens A keeps but B drops) is computed
+   the way the real-model harness will.
+
+Run directly::
+
+    python test/srt/mem_cache/test_rkv_prefill.py
+"""
+
+import importlib.util
+import os
+import unittest
+
+import torch
+
+_HERE = os.path.dirname(__file__)
+_RKV_DIR = os.path.abspath(
+    os.path.join(_HERE, "..", "rkv")
+)
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_RKV_DIR, filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_algo = _load("rkv_algo", "algo.py")
+_prefill = _load("rkv_prefill", "prefill.py")
+
+R1KV = _algo.R1KV
+cal_similarity = _algo.cal_similarity
+cal_similarity_tiled = _prefill.cal_similarity_tiled
+RKVPrefill = _prefill.RKVPrefill
+
+
+# --------------------------------------------------------------------------- #
+# Diff-test metrics (reused by the real-model capture harness)                 #
+# --------------------------------------------------------------------------- #
+def diff_metrics(kept_a: torch.Tensor, kept_b: torch.Tensor, n: int) -> dict:
+    """Compare two kept-index sets. ``kept_a`` is the oracle (route A).
+
+    Returns Jaccard overlap, the count of tokens A keeps but B drops (premature
+    evictions), and the recall of B against A.
+    """
+    a = set(kept_a.tolist())
+    b = set(kept_b.tolist())
+    inter = len(a & b)
+    union = len(a | b)
+    premature = len(a - b)  # A keeps, B dropped -> candidate premature evictions
+    return {
+        "n": n,
+        "budget": len(a),
+        "jaccard": inter / union if union else 1.0,
+        "recall_b_vs_a": inter / len(a) if a else 1.0,
+        "premature_evictions": premature,
+    }
+
+
+def _rand_layers(num_layers, kv_heads, q_heads, n, d, seed=0, dtype=torch.float32):
+    g = torch.Generator().manual_seed(seed)
+    keys = [
+        torch.randn(kv_heads, n, d, generator=g, dtype=dtype) for _ in range(num_layers)
+    ]
+    queries = [
+        torch.randn(q_heads, n, d, generator=g, dtype=dtype) for _ in range(num_layers)
+    ]
+    return keys, queries
+
+
+class TestTiledSimilarityParity(unittest.TestCase):
+    def test_matches_reference_last(self):
+        torch.manual_seed(0)
+        for n in (37, 128, 500):
+            key = torch.randn(1, 4, n, 16, dtype=torch.float32)
+            ref = cal_similarity(key, retain_direction="last")
+            # Force multiple row blocks to exercise the tiling path.
+            got = cal_similarity_tiled(key, retain_direction="last", row_block=64)
+            self.assertEqual(ref.shape, got.shape)
+            self.assertTrue(
+                torch.allclose(ref, got, atol=1e-6, rtol=1e-5),
+                f"tiled similarity diverged at n={n}: max abs "
+                f"{(ref - got).abs().max().item():.3e}",
+            )
+
+    def test_single_block_equals_reference(self):
+        torch.manual_seed(1)
+        key = torch.randn(1, 3, 96, 16, dtype=torch.float32)
+        ref = cal_similarity(key, retain_direction="last")
+        got = cal_similarity_tiled(key, retain_direction="last", row_block=10_000)
+        self.assertTrue(torch.allclose(ref, got, atol=1e-6, rtol=1e-5))
+
+
+class TestOneShotParity(unittest.TestCase):
+    """Route A single-layer selection must match a direct full-matrix R-KV pick."""
+
+    def test_oneshot_matches_algo_select(self):
+        torch.manual_seed(2)
+        kv_heads, q_heads, n, d = 2, 2, 300, 16
+        budget, window = 64, 8
+        key = torch.randn(1, kv_heads, n, d, dtype=torch.float32)
+        query = torch.randn(1, q_heads, n, d, dtype=torch.float32)
+
+        # Reference: full-matrix R-KV score, head-mean, top past + window.
+        algo = R1KV(budget=budget, window_size=window, mix_lambda=0.1, retain_ratio=0.1)
+        window_q = query[:, :, -window:, :]
+        score = algo._scores(key, window_q).mean(dim=1).squeeze(0)  # (n-window,)
+        past = score.topk(budget - window).indices
+        win = torch.arange(n - window, n)
+        ref = torch.sort(torch.cat([past, win])).values
+
+        # Route A one-shot (tiled).
+        pf = RKVPrefill(
+            budget=budget, window_size=window, mix_lambda=0.1, retain_ratio=0.1
+        )
+        got = pf.oneshot_keep([key.squeeze(0)], [window_q.squeeze(0)])
+
+        self.assertTrue(torch.equal(ref, got))
+
+
+class TestRouteInvariants(unittest.TestCase):
+    def setUp(self):
+        self.kv_heads, self.q_heads, self.n, self.d = 2, 4, 2000, 16
+        self.budget, self.window = 256, 8
+        self.keys, self.queries = _rand_layers(
+            num_layers=3,
+            kv_heads=self.kv_heads,
+            q_heads=self.q_heads,
+            n=self.n,
+            d=self.d,
+            seed=3,
+        )
+        self.pf = RKVPrefill(
+            budget=self.budget, window_size=self.window, mix_lambda=0.1
+        )
+        self.window_q = [q[:, -self.window :, :] for q in self.queries]
+
+    def test_oneshot_shape_and_window(self):
+        kept = self.pf.oneshot_keep(self.keys, self.window_q)
+        self.assertEqual(kept.numel(), self.budget)
+        self.assertTrue(torch.equal(torch.sort(kept).values, kept))  # ascending
+        # Trailing window always kept.
+        win = set(range(self.n - self.window, self.n))
+        self.assertTrue(win.issubset(set(kept.tolist())))
+
+    def test_buffered_shape_and_window(self):
+        kept = self.pf.buffered_keep(
+            self.keys, self.queries, chunk_size=512, buffer=128
+        )
+        self.assertEqual(kept.numel(), self.budget)
+        self.assertTrue(torch.equal(torch.sort(kept).values, kept))
+        win = set(range(self.n - self.window, self.n))
+        self.assertTrue(win.issubset(set(kept.tolist())))
+
+    def test_buffered_infinite_buffer_recovers_oneshot(self):
+        # buffer >= n means no mid-prefill compaction; the single final
+        # compaction scores against the true final window == route A exactly.
+        a = self.pf.oneshot_keep(self.keys, self.window_q)
+        b = self.pf.buffered_keep(
+            self.keys, self.queries, chunk_size=256, buffer=self.n + 1
+        )
+        self.assertTrue(torch.equal(a, b))
+
+    def test_buffered_no_compaction_below_budget(self):
+        short_keys = [k[:, : self.budget - 1, :] for k in self.keys]
+        short_q = [q[:, : self.budget - 1, :] for q in self.queries]
+        kept = self.pf.buffered_keep(short_keys, short_q, chunk_size=64, buffer=32)
+        self.assertEqual(kept.numel(), self.budget - 1)
+
+    def test_diff_metric_runs(self):
+        a = self.pf.oneshot_keep(self.keys, self.window_q)
+        b = self.pf.buffered_keep(self.keys, self.queries, chunk_size=512, buffer=128)
+        m = diff_metrics(a, b, self.n)
+        self.assertEqual(m["budget"], self.budget)
+        self.assertGreaterEqual(m["jaccard"], 0.0)
+        self.assertLessEqual(m["jaccard"], 1.0)
+        # The trailing window is kept by both, so overlap is never zero.
+        self.assertGreaterEqual(m["premature_evictions"], 0)
+
+
+class TestBatchedScoreParity(unittest.TestCase):
+    """``batched_past_score`` over stacked layers == per-layer ``layer_past_score`` sum."""
+
+    def test_batched_equals_per_layer_sum(self):
+        torch.manual_seed(3)
+        num_layers, kv_heads, q_heads, n, window, d = 4, 2, 8, 96, 8, 16
+        budget = 32
+        pf = RKVPrefill(budget=budget, window_size=window, mix_lambda=0.1)
+        keys = torch.randn(num_layers, kv_heads, n, d, dtype=torch.float32)
+        window_q = torch.randn(num_layers, q_heads, window, d, dtype=torch.float32)
+
+        # Per-layer reference (bsz=1 loop, summed over layers).
+        ref = None
+        for layer in range(num_layers):
+            s = pf.layer_past_score(
+                keys[layer : layer + 1], window_q[layer : layer + 1]
+            )
+            ref = s if ref is None else ref + s
+
+        # Batched (num_layers as the batch dim), summed over layers.
+        bat = pf.batched_past_score(keys, window_q).sum(dim=0)  # (n-w,)
+
+        self.assertEqual(ref.shape, bat.shape)
+        self.assertTrue(
+            torch.allclose(ref, bat, atol=1e-5, rtol=1e-5),
+            f"batched score diverged: max abs {(ref - bat).abs().max().item():.3e}",
+        )
+        # The selection (top past tokens) must be identical — this is the gate.
+        num_past = budget - window
+        self.assertTrue(
+            torch.equal(
+                torch.sort(ref.topk(num_past).indices).values,
+                torch.sort(bat.topk(num_past).indices).values,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/SGLang/tests/test_rkv_prefill_integration.py
+++ b/SGLang/tests/test_rkv_prefill_integration.py
@@ -1,0 +1,428 @@
+"""CPU unit tests for the R-KV **prefill** integration layer (RKVPrefillCompressor).
+
+GPU-free; loads the algorithm + integration modules by file path (bypassing
+``sglang/__init__.py``). Focuses on the serving-facing behaviour: config
+validation, the ``task_type`` gate, kept-index assembly, physical compaction
+(KV relocation / free / ``req_to_token`` rewrite / length bookkeeping), and the
+one-shot and buffered end-to-end observe->compact paths.
+
+Run directly::
+
+    python test/srt/mem_cache/test_rkv_prefill_integration.py
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+import torch
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_RKV_DIR = os.path.abspath(
+    os.path.join(_HERE, "..", "rkv")
+)
+
+
+def _load_by_path(dotted_name, file_path):
+    spec = importlib.util.spec_from_file_location(dotted_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[dotted_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+for _pkg in (
+    "sglang",
+    "sglang.srt",
+    "sglang.srt.mem_cache",
+    "sglang.srt.mem_cache.rkv",
+):
+    if _pkg not in sys.modules:
+        _ph = types.ModuleType(_pkg)
+        _ph.__path__ = []
+        sys.modules[_pkg] = _ph
+
+# prefill_integration.py declares its config as a ``msgspec.Struct`` (repo
+# convention, see .claude/rules/no-dataclasses.md). msgspec is a real SGLang
+# runtime dependency, but this suite is GPU-free and installs only torch, so it
+# may be absent. Provide a tiny stand-in backed by ``dataclasses`` when it is:
+# the Struct uses only plain-typed fields with immutable defaults plus a
+# ``__post_init__``, all of which dataclasses reproduce exactly. Mirrors the
+# ``sglang.*`` placeholder packages above.
+try:
+    import msgspec  # noqa: F401
+except ModuleNotFoundError:
+    import dataclasses
+
+    _msgspec_stub = types.ModuleType("msgspec")
+
+    class _Struct:
+        def __init_subclass__(cls, **kwargs):
+            super().__init_subclass__(**kwargs)
+            dataclasses.dataclass(cls)
+
+    _msgspec_stub.Struct = _Struct
+    sys.modules["msgspec"] = _msgspec_stub
+
+_load_by_path("sglang.srt.mem_cache.rkv.algo", os.path.join(_RKV_DIR, "algo.py"))
+_load_by_path("sglang.srt.mem_cache.rkv.prefill", os.path.join(_RKV_DIR, "prefill.py"))
+_integration = _load_by_path(
+    "sglang.srt.mem_cache.rkv.prefill_integration",
+    os.path.join(_RKV_DIR, "prefill_integration.py"),
+)
+
+RKVPrefillConfig = _integration.RKVPrefillConfig
+RKVPrefillRequestState = _integration.RKVPrefillRequestState
+RKVPrefillCompressor = _integration.RKVPrefillCompressor
+
+
+# --------------------------------------------------------------------------- #
+# Minimal mocks                                                                #
+# --------------------------------------------------------------------------- #
+class MockReqToTokenPool:
+    def __init__(self, num_reqs, max_ctx, device):
+        self.req_to_token = torch.zeros(
+            (num_reqs + 1, max_ctx), dtype=torch.int32, device=device
+        )
+
+
+class MockKVPool:
+    def __init__(self, num_layers, num_slots, head_num, head_dim, device, dtype):
+        self.k_buffers = [
+            torch.randn((num_slots, head_num, head_dim), device=device, dtype=dtype)
+            for _ in range(num_layers)
+        ]
+        self.v_buffers = [
+            torch.randn((num_slots, head_num, head_dim), device=device, dtype=dtype)
+            for _ in range(num_layers)
+        ]
+
+    def get_key_buffer(self, layer_id):
+        return self.k_buffers[layer_id]
+
+    def get_value_buffer(self, layer_id):
+        return self.v_buffers[layer_id]
+
+
+class MockAllocator:
+    def __init__(self):
+        self.freed = []
+
+    def free(self, free_index):
+        self.freed.append(free_index.clone())
+
+
+class _MockReq:
+    def __init__(self, origin_len, output_len=0, req_pool_idx=1):
+        self.origin_input_ids = list(range(origin_len))
+        self.output_ids = list(range(output_len))
+        self.kv_committed_len = origin_len + output_len
+        self.kv_allocated_len = origin_len + output_len
+        self.req_pool_idx = req_pool_idx
+
+    @property
+    def seqlen(self):
+        return len(self.origin_input_ids) + len(self.output_ids)
+
+
+class _MockLayer:
+    def __init__(self, layer_id):
+        self.layer_id = layer_id
+
+
+class _MockForwardBatch:
+    def __init__(self, req_pool_indices, seq_lens, extend_seq_lens, positions=None):
+        self.req_pool_indices = torch.tensor(req_pool_indices, dtype=torch.int64)
+        self.seq_lens = torch.tensor(seq_lens, dtype=torch.int64)
+        self.seq_lens_cpu = self.seq_lens.clone()
+        self.extend_seq_lens = torch.tensor(extend_seq_lens, dtype=torch.int64)
+        self.extend_seq_lens_cpu = extend_seq_lens
+        self.positions = positions
+
+
+def _make_compressor(
+    mode,
+    budget,
+    window,
+    num_layers,
+    head_num,
+    head_dim,
+    num_slots,
+    kv_heads=None,
+    buffer=0,
+):
+    device = torch.device("cpu")
+    kv_heads = kv_heads or head_num
+    cfg = RKVPrefillConfig(
+        mode=mode, budget=budget, window_size=window, kernel_size=7, buffer=buffer
+    )
+    return RKVPrefillCompressor(
+        config=cfg,
+        req_to_token_pool=MockReqToTokenPool(4, 4096, device),
+        token_to_kv_pool=MockKVPool(
+            num_layers, num_slots, kv_heads, head_dim, device, torch.float32
+        ),
+        kv_allocator=MockAllocator(),
+        start_layer=0,
+        end_layer=num_layers,
+        device=device,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Tests                                                                        #
+# --------------------------------------------------------------------------- #
+class TestConfig(unittest.TestCase):
+    def test_defaults_and_validation(self):
+        cfg = RKVPrefillConfig()
+        self.assertEqual(cfg.mode, "oneshot")
+        with self.assertRaises(ValueError):
+            RKVPrefillConfig(mode="nope")
+        with self.assertRaises(ValueError):
+            RKVPrefillConfig(budget=8, window_size=8)
+
+
+class TestUnconditionalCompression(unittest.TestCase):
+    def test_always_wants_compression(self):
+        # R-KV prefill is unconditional: every request is compressed when enabled.
+        f = RKVPrefillCompressor.request_wants_compression
+        self.assertTrue(f(_MockReq(10)))
+        self.assertTrue(f(_MockReq(500, output_len=20)))
+
+
+class TestAssembleKept(unittest.TestCase):
+    def test_top_past_plus_window_sorted(self):
+        comp = _make_compressor(
+            "oneshot",
+            budget=4,
+            window=2,
+            num_layers=1,
+            head_num=1,
+            head_dim=4,
+            num_slots=64,
+        )
+        score = torch.tensor([0.1, 9.0, 0.2, 8.0])  # past [0,4)
+        kept = comp._assemble_kept(score, seq_len=6)
+        self.assertEqual(sorted(kept.tolist()), [1, 3, 4, 5])
+
+
+class TestOneShotEndToEnd(unittest.TestCase):
+    def test_single_chunk_prefill_compacts(self):
+        budget, window, n = 8, 2, 20
+        num_layers, kv_heads, q_heads, head_dim = 3, 2, 2, 8
+        comp = _make_compressor(
+            "oneshot", budget, window, num_layers, kv_heads, head_dim, num_slots=64
+        )
+        idx = 1
+        slots = torch.arange(30, 30 + n, dtype=torch.int32)
+        comp.req_to_token_pool.req_to_token[idx, :n] = slots
+
+        req = _MockReq(origin_len=n, req_pool_idx=idx)
+        comp.on_request_begin(req)
+
+        fb = _MockForwardBatch([idx], [n], [n])
+        q = torch.randn(n, q_heads, head_dim)
+        for layer_id in range(num_layers):
+            comp.observe_prefill_layer(q, None, None, _MockLayer(layer_id), fb)
+        comp.maybe_compact(fb)
+
+        state = comp.states[idx]
+        self.assertTrue(state.compressed)
+        self.assertEqual(req.kv_committed_len, budget)
+        self.assertEqual(comp.take_pending_length_updates()[idx], budget)
+        # freed exactly n - budget slots; tail of req_to_token cleared.
+        self.assertEqual(int(comp.kv_allocator.freed[0].numel()), n - budget)
+        r2t = comp.req_to_token_pool.req_to_token
+        self.assertTrue(bool((r2t[idx, :budget] != 0).all()))
+        self.assertTrue(bool((r2t[idx, budget:n] == 0).all()))
+
+    def test_reprefill_after_retract_frees_regenerated_slots(self):
+        # A retracted request keeps its output_ids and re-prefills
+        # origin_input_ids + output_ids, allocating (origin + output) KV slots.
+        # Compaction must free the FULL physical tail, not orphan the
+        # regenerated output slots (KV-pool leak regression).
+        budget, window, origin, output = 8, 2, 20, 12
+        n = origin + output  # physical prefill length after re-prefill
+        num_layers, kv_heads, q_heads, head_dim = 3, 2, 2, 8
+        comp = _make_compressor(
+            "oneshot", budget, window, num_layers, kv_heads, head_dim, num_slots=64
+        )
+        idx = 1
+        slots = torch.arange(30, 30 + n, dtype=torch.int32)
+        comp.req_to_token_pool.req_to_token[idx, :n] = slots
+
+        req = _MockReq(origin_len=origin, output_len=output, req_pool_idx=idx)
+        comp.on_request_begin(req)
+        # prompt_len tracks the full physical length (origin + output).
+        self.assertEqual(comp.states[idx].prompt_len, n)
+
+        fb = _MockForwardBatch([idx], [n], [n])
+        q = torch.randn(n, q_heads, head_dim)
+        for layer_id in range(num_layers):
+            comp.observe_prefill_layer(q, None, None, _MockLayer(layer_id), fb)
+        comp.maybe_compact(fb)
+
+        # Frees the full tail (n - budget); no output slot left orphaned.
+        self.assertEqual(int(comp.kv_allocator.freed[0].numel()), n - budget)
+        r2t = comp.req_to_token_pool.req_to_token
+        self.assertTrue(bool((r2t[idx, budget:n] == 0).all()))
+        self.assertEqual(req.kv_committed_len, budget)
+        self.assertEqual(req.kv_allocated_len, budget)
+
+    def test_below_budget_no_compaction(self):
+        budget, window, n = 32, 2, 20  # n < budget
+        comp = _make_compressor("oneshot", budget, window, 2, 2, 8, num_slots=64)
+        idx = 1
+        comp.req_to_token_pool.req_to_token[idx, :n] = torch.arange(
+            5, 5 + n, dtype=torch.int32
+        )
+        req = _MockReq(origin_len=n, req_pool_idx=idx)
+        comp.on_request_begin(req)
+        fb = _MockForwardBatch([idx], [n], [n])
+        q = torch.randn(n, 2, 8)
+        for layer_id in range(2):
+            comp.observe_prefill_layer(q, None, None, _MockLayer(layer_id), fb)
+        comp.maybe_compact(fb)
+        self.assertFalse(comp.states[idx].compressed)
+        self.assertEqual(len(comp.kv_allocator.freed), 0)
+
+
+class TestBufferedCompaction(unittest.TestCase):
+    def test_triggers_above_budget_plus_buffer(self):
+        budget, window, buffer, n = 8, 2, 4, 20  # n > budget + buffer
+        num_layers, kv_heads, q_heads, head_dim = 2, 2, 2, 8
+        comp = _make_compressor(
+            "buffered",
+            budget,
+            window,
+            num_layers,
+            kv_heads,
+            head_dim,
+            num_slots=64,
+            buffer=buffer,
+        )
+        idx = 1
+        comp.req_to_token_pool.req_to_token[idx, :n] = torch.arange(
+            40, 40 + n, dtype=torch.int32
+        )
+        req = _MockReq(origin_len=n, req_pool_idx=idx)
+        comp.on_request_begin(req)
+
+        fb = _MockForwardBatch([idx], [n], [n])
+        q = torch.randn(n, q_heads, head_dim)
+        for layer_id in range(num_layers):
+            comp.observe_prefill_layer(q, None, None, _MockLayer(layer_id), fb)
+        # Logical compaction already shrank kept_orig to budget by the last layer.
+        state = comp.states[idx]
+        self.assertIsNotNone(state.kept_orig)
+        self.assertEqual(state.kept_orig.numel(), budget)
+        # End-of-prefill physical compaction (final chunk: seq_len == prompt_len).
+        comp.maybe_compact(fb)
+        self.assertTrue(
+            state.compressed
+        )  # buffered latches after the one physical pass
+        self.assertEqual(req.kv_committed_len, budget)
+        self.assertEqual(int(comp.kv_allocator.freed[0].numel()), n - budget)
+
+    def test_final_forced_compaction_within_buffer(self):
+        # budget < n <= budget + buffer: no mid-prefill logical compaction, but
+        # the end-of-prefill forced pass still shrinks to budget (route B always
+        # ends at budget, matching the pure algorithm).
+        budget, window, buffer, n = 8, 2, 20, 20  # n <= budget + buffer
+        comp = _make_compressor(
+            "buffered", budget, window, 2, 2, 8, num_slots=64, buffer=buffer
+        )
+        idx = 1
+        comp.req_to_token_pool.req_to_token[idx, :n] = torch.arange(
+            40, 40 + n, dtype=torch.int32
+        )
+        req = _MockReq(origin_len=n, req_pool_idx=idx)
+        comp.on_request_begin(req)
+        fb = _MockForwardBatch([idx], [n], [n])
+        q = torch.randn(n, 2, 8)
+        for layer_id in range(2):
+            comp.observe_prefill_layer(q, None, None, _MockLayer(layer_id), fb)
+        # No mid-prefill compaction: kept_orig still holds all n tokens.
+        self.assertEqual(comp.states[idx].kept_orig.numel(), n)
+        comp.maybe_compact(fb)
+        self.assertTrue(comp.states[idx].compressed)
+        self.assertEqual(int(comp.kv_allocator.freed[0].numel()), n - budget)
+
+    def test_below_budget_no_compaction(self):
+        budget, window, buffer, n = 32, 2, 8, 20  # n < budget
+        comp = _make_compressor(
+            "buffered", budget, window, 2, 2, 8, num_slots=64, buffer=buffer
+        )
+        idx = 1
+        comp.req_to_token_pool.req_to_token[idx, :n] = torch.arange(
+            40, 40 + n, dtype=torch.int32
+        )
+        req = _MockReq(origin_len=n, req_pool_idx=idx)
+        comp.on_request_begin(req)
+        fb = _MockForwardBatch([idx], [n], [n])
+        q = torch.randn(n, 2, 8)
+        for layer_id in range(2):
+            comp.observe_prefill_layer(q, None, None, _MockLayer(layer_id), fb)
+        comp.maybe_compact(fb)
+        self.assertFalse(comp.states[idx].compressed)
+        self.assertEqual(len(comp.kv_allocator.freed), 0)
+
+    def test_multichunk_kept_orig_evolves(self):
+        # Two chunks; buffer small so a logical compaction fires after chunk 1.
+        budget, window, buffer = 8, 2, 2
+        num_layers, kv_heads, q_heads, head_dim = 2, 2, 2, 8
+        comp = _make_compressor(
+            "buffered",
+            budget,
+            window,
+            num_layers,
+            kv_heads,
+            head_dim,
+            num_slots=128,
+            buffer=buffer,
+        )
+        idx = 1
+        n = 24
+        comp.req_to_token_pool.req_to_token[idx, :n] = torch.arange(
+            50, 50 + n, dtype=torch.int32
+        )
+        req = _MockReq(origin_len=n, req_pool_idx=idx)
+        comp.on_request_begin(req)
+
+        # chunk 1: tokens [0, 12), seq_len=12
+        q1 = torch.randn(12, q_heads, head_dim)
+        fb1 = _MockForwardBatch([idx], [12], [12])
+        for layer_id in range(num_layers):
+            comp.observe_prefill_layer(q1, None, None, _MockLayer(layer_id), fb1)
+        # 12 > budget+buffer(10) -> logically compacted to budget after chunk 1.
+        self.assertEqual(comp.states[idx].kept_orig.numel(), budget)
+
+        # chunk 2: tokens [12, 24), seq_len=24 (final)
+        q2 = torch.randn(12, q_heads, head_dim)
+        fb2 = _MockForwardBatch([idx], [24], [12])
+        for layer_id in range(num_layers):
+            comp.observe_prefill_layer(q2, None, None, _MockLayer(layer_id), fb2)
+        comp.maybe_compact(fb2)
+        state = comp.states[idx]
+        self.assertTrue(state.compressed)
+        self.assertEqual(req.kv_committed_len, budget)
+        self.assertEqual(int(comp.kv_allocator.freed[0].numel()), n - budget)
+
+
+class TestDecodePositions(unittest.TestCase):
+    def test_override_uses_logical(self):
+        comp = _make_compressor("oneshot", 8, 2, 1, 2, 8, num_slots=64)
+        idx = 1
+        req = _MockReq(origin_len=100, output_len=5, req_pool_idx=idx)
+        comp.on_request_begin(req)
+        positions = torch.tensor([0], dtype=torch.int64)
+        fb = _MockForwardBatch([idx], [8], [0], positions=positions)
+        comp.override_decode_positions(fb)
+        # logical_position - 1 = 100 + 5 - 1 = 104
+        self.assertEqual(int(fb.positions[0]), 104)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/SGLang/tests/test_rkv_prefill_integration.py
+++ b/SGLang/tests/test_rkv_prefill_integration.py
@@ -183,6 +183,14 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(ValueError):
             RKVPrefillConfig(budget=8, window_size=8)
 
+    def test_even_kernel_and_bad_dims_rejected(self):
+        with self.assertRaises(ValueError):
+            RKVPrefillConfig(kernel_size=8)  # even kernel breaks R1KV._scores
+        with self.assertRaises(ValueError):
+            RKVPrefillConfig(window_size=0)
+        with self.assertRaises(ValueError):
+            RKVPrefillConfig(row_block=0)
+
 
 class TestUnconditionalCompression(unittest.TestCase):
     def test_always_wants_compression(self):
@@ -231,7 +239,7 @@ class TestOneShotEndToEnd(unittest.TestCase):
         state = comp.states[idx]
         self.assertTrue(state.compressed)
         self.assertEqual(req.kv_committed_len, budget)
-        self.assertEqual(comp.take_pending_length_updates()[idx], budget)
+        self.assertEqual(comp.take_pending_length_updates()[idx][0], budget)
         # freed exactly n - budget slots; tail of req_to_token cleared.
         self.assertEqual(int(comp.kv_allocator.freed[0].numel()), n - budget)
         r2t = comp.req_to_token_pool.req_to_token
@@ -422,6 +430,59 @@ class TestDecodePositions(unittest.TestCase):
         comp.override_decode_positions(fb)
         # logical_position - 1 = 100 + 5 - 1 = 104
         self.assertEqual(int(fb.positions[0]), 104)
+
+
+class TestPrefillPendingLifecycle(unittest.TestCase):
+    """Issue 1 (prefill): a request that compacts at prefill end and finishes on
+    the same step (the normal prefill-finish path) must not leak its pending
+    length update to the next request reusing the slot."""
+
+    def _comp(self):
+        return _make_compressor("oneshot", 8, 2, 3, 2, 8, num_slots=64)
+
+    def _compact(self, comp, idx, n=20):
+        comp.req_to_token_pool.req_to_token[idx, :n] = torch.arange(
+            30, 30 + n, dtype=torch.int32
+        )
+        req = _MockReq(origin_len=n, req_pool_idx=idx)
+        comp.on_request_begin(req)
+        fb = _MockForwardBatch([idx], [n], [n])
+        q = torch.randn(n, 2, 8)
+        for layer_id in range(comp.num_layers):
+            comp.observe_prefill_layer(q, None, None, _MockLayer(layer_id), fb)
+        comp.maybe_compact(fb)
+        return req
+
+    def test_pending_update_carries_owner(self):
+        comp = self._comp()
+        req = self._compact(comp, 1)
+        new_len, owner = comp.pending_length_updates[1]
+        self.assertEqual(new_len, 8)
+        self.assertIs(owner, req)
+
+    def test_finish_clears_pending(self):
+        comp = self._comp()
+        req = self._compact(comp, 1)
+        self.assertIn(1, comp.pending_length_updates)
+        comp.on_request_end(req)
+        self.assertNotIn(1, comp.pending_length_updates)
+        self.assertNotIn(1, comp.states)
+
+    def test_retract_clears_pending(self):
+        comp = self._comp()
+        req = self._compact(comp, 1)
+        self.assertIn(1, comp.pending_length_updates)
+        comp.on_request_retract(req)
+        self.assertNotIn(1, comp.pending_length_updates)
+        self.assertNotIn(1, comp.states)
+
+    def test_slot_reuse_after_finish_no_stale(self):
+        comp = self._comp()
+        req_a = self._compact(comp, 1)
+        comp.on_request_end(req_a)
+        req_b = _MockReq(origin_len=5, req_pool_idx=1)
+        comp.on_request_begin(req_b)  # B reuses slot 1
+        self.assertEqual(comp.take_pending_length_updates(), {})
 
 
 if __name__ == "__main__":

--- a/SGLang/tests/test_rkv_redundancy_fused.py
+++ b/SGLang/tests/test_rkv_redundancy_fused.py
@@ -24,32 +24,6 @@ _RKV_DIR = os.path.abspath(
     os.path.join(_HERE, "..", "rkv")
 )
 
-# Standalone layout (no installed ``sglang``): register the R-KV modules under
-# their real ``sglang.srt.mem_cache.rkv.*`` dotted names so the lazy cross-module
-# imports inside algo.py / prefill.py (redundancy_fused, prefill, algo) resolve.
-for _pkg in (
-    "sglang",
-    "sglang.srt",
-    "sglang.srt.mem_cache",
-    "sglang.srt.mem_cache.rkv",
-):
-    if _pkg not in sys.modules:
-        _placeholder = types.ModuleType(_pkg)
-        _placeholder.__path__ = []  # mark as package
-        sys.modules[_pkg] = _placeholder
-for _dotted, _fname in (
-    ("sglang.srt.mem_cache.rkv.redundancy_fused", "redundancy_fused.py"),
-    ("sglang.srt.mem_cache.rkv.algo", "algo.py"),
-    ("sglang.srt.mem_cache.rkv.prefill", "prefill.py"),
-):
-    if _dotted not in sys.modules:
-        _spec = importlib.util.spec_from_file_location(
-            _dotted, os.path.join(_RKV_DIR, _fname)
-        )
-        _module = importlib.util.module_from_spec(_spec)
-        sys.modules[_dotted] = _module
-        _spec.loader.exec_module(_module)
-
 _HAS_CUDA = torch.cuda.is_available()
 try:
     import triton  # noqa: F401
@@ -57,6 +31,36 @@ try:
     _HAS_TRITON = True
 except Exception:
     _HAS_TRITON = False
+
+# Standalone port (no installed ``sglang``): register the R-KV modules under
+# their real ``sglang.srt.mem_cache.rkv.*`` dotted names so the lazy cross-module
+# imports inside algo.py / prefill.py resolve. GUARDED by Triton availability,
+# because redundancy_fused.py imports Triton at module load and every test in
+# this file is skipped without CUDA+Triton anyway -- so on a CPU / no-Triton
+# runner this file self-skips instead of raising ModuleNotFoundError.
+if _HAS_TRITON:
+    for _pkg in (
+        "sglang",
+        "sglang.srt",
+        "sglang.srt.mem_cache",
+        "sglang.srt.mem_cache.rkv",
+    ):
+        if _pkg not in sys.modules:
+            _placeholder = types.ModuleType(_pkg)
+            _placeholder.__path__ = []  # mark as package
+            sys.modules[_pkg] = _placeholder
+    for _dotted, _fname in (
+        ("sglang.srt.mem_cache.rkv.redundancy_fused", "redundancy_fused.py"),
+        ("sglang.srt.mem_cache.rkv.algo", "algo.py"),
+        ("sglang.srt.mem_cache.rkv.prefill", "prefill.py"),
+    ):
+        if _dotted not in sys.modules:
+            _spec = importlib.util.spec_from_file_location(
+                _dotted, os.path.join(_RKV_DIR, _fname)
+            )
+            _module = importlib.util.module_from_spec(_spec)
+            sys.modules[_dotted] = _module
+            _spec.loader.exec_module(_module)
 
 
 def _load(name, filename):

--- a/SGLang/tests/test_rkv_redundancy_fused.py
+++ b/SGLang/tests/test_rkv_redundancy_fused.py
@@ -1,0 +1,319 @@
+"""GPU parity tests for the fused R-KV redundancy kernel.
+
+These require CUDA + Triton and are skipped otherwise (the CPU-by-path suite in
+``test_rkv_prefill.py`` covers the reference ``cal_similarity_tiled``). Stage 1
+checks the fused kernel WITHOUT the retain exemption against a no-retain torch
+reference; Stage 2 will add the retain exemption and bit-parity vs the full
+reference.
+
+Run directly (on a GPU box)::
+
+    python test/srt/mem_cache/test_rkv_redundancy_fused.py
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+
+import torch
+
+_HERE = os.path.dirname(__file__)
+_RKV_DIR = os.path.abspath(
+    os.path.join(_HERE, "..", "rkv")
+)
+
+# Standalone layout (no installed ``sglang``): register the R-KV modules under
+# their real ``sglang.srt.mem_cache.rkv.*`` dotted names so the lazy cross-module
+# imports inside algo.py / prefill.py (redundancy_fused, prefill, algo) resolve.
+for _pkg in (
+    "sglang",
+    "sglang.srt",
+    "sglang.srt.mem_cache",
+    "sglang.srt.mem_cache.rkv",
+):
+    if _pkg not in sys.modules:
+        _placeholder = types.ModuleType(_pkg)
+        _placeholder.__path__ = []  # mark as package
+        sys.modules[_pkg] = _placeholder
+for _dotted, _fname in (
+    ("sglang.srt.mem_cache.rkv.redundancy_fused", "redundancy_fused.py"),
+    ("sglang.srt.mem_cache.rkv.algo", "algo.py"),
+    ("sglang.srt.mem_cache.rkv.prefill", "prefill.py"),
+):
+    if _dotted not in sys.modules:
+        _spec = importlib.util.spec_from_file_location(
+            _dotted, os.path.join(_RKV_DIR, _fname)
+        )
+        _module = importlib.util.module_from_spec(_spec)
+        sys.modules[_dotted] = _module
+        _spec.loader.exec_module(_module)
+
+_HAS_CUDA = torch.cuda.is_available()
+try:
+    import triton  # noqa: F401
+
+    _HAS_TRITON = True
+except Exception:
+    _HAS_TRITON = False
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_RKV_DIR, filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ref_noretain(key: torch.Tensor) -> torch.Tensor:
+    """Redundancy with only the diagonal zeroed (no retain exemption)."""
+    k_norm = key / (key.norm(dim=-1, keepdim=True) + 1e-8)
+    sim = torch.matmul(k_norm, k_norm.transpose(-1, -2))
+    n = key.shape[-2]
+    diag = torch.eye(n, dtype=torch.bool, device=key.device)
+    sim.masked_fill_(diag.view(1, 1, n, n), 0.0)
+    return sim.to(torch.float32).mean(dim=-2).softmax(dim=-1).to(key.dtype)
+
+
+@unittest.skipUnless(
+    _HAS_CUDA and _HAS_TRITON, "fused redundancy kernel needs CUDA + Triton"
+)
+class TestFusedRedundancyNoRetain(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fused = staticmethod(
+            _load(
+                "rkv_redundancy_fused", "redundancy_fused.py"
+            ).cal_similarity_fused_noretain
+        )
+
+    def test_parity_fp32(self):
+        for n in (37, 128, 512, 2000):
+            torch.manual_seed(0)
+            key = torch.randn(1, 4, n, 128, device="cuda", dtype=torch.float32)
+            ref = _ref_noretain(key)
+            got = self.fused(key)
+            self.assertEqual(ref.shape, got.shape)
+            self.assertTrue(
+                torch.allclose(ref, got, atol=2e-4, rtol=1e-3),
+                f"fp32 fused diverged at n={n}: "
+                f"max {(ref - got).abs().max().item():.3e}",
+            )
+
+    def test_parity_bf16(self):
+        for n in (128, 512, 2000):
+            torch.manual_seed(1)
+            key = torch.randn(1, 4, n, 128, device="cuda", dtype=torch.bfloat16)
+            ref = _ref_noretain(key)
+            got = self.fused(key)
+            self.assertTrue(
+                torch.allclose(ref.float(), got.float(), atol=2e-2, rtol=1e-3),
+                f"bf16 fused diverged at n={n}: "
+                f"max {(ref.float() - got.float()).abs().max().item():.3e}",
+            )
+
+    def test_multi_layer_leading_dims(self):
+        # Leading (layers, kv_heads) dims are flattened and reduced independently.
+        torch.manual_seed(2)
+        key = torch.randn(3, 4, 200, 128, device="cuda", dtype=torch.float32)
+        got = self.fused(key)
+        self.assertEqual(got.shape, (3, 4, 200))
+        # Each (layer, head) row is a probability distribution over n.
+        sums = got.sum(dim=-1)
+        self.assertTrue(torch.allclose(sums, torch.ones_like(sums), atol=1e-4))
+
+
+@unittest.skipUnless(
+    _HAS_CUDA and _HAS_TRITON, "fused redundancy kernel needs CUDA + Triton"
+)
+class TestFusedRedundancyRetain(unittest.TestCase):
+    """Fused kernel WITH the retain exemption must match cal_similarity_tiled."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fused = staticmethod(
+            _load("rkv_redundancy_fused", "redundancy_fused.py").cal_similarity_fused
+        )
+        cls.tiled = staticmethod(
+            _load("rkv_prefill", "prefill.py").cal_similarity_tiled
+        )
+
+    def test_bitparity_fp32(self):
+        for thr in (0.0, 0.3, 0.5, 0.9):
+            for n in (37, 128, 512, 1500):
+                torch.manual_seed(n)
+                key = torch.randn(1, 4, n, 128, device="cuda", dtype=torch.float32)
+                ref = self.tiled(key, threshold=thr, retain_direction="last")
+                got = self.fused(key, threshold=thr)
+                self.assertTrue(
+                    torch.allclose(ref, got, atol=5e-4, rtol=1e-3),
+                    f"fp32 retain diverged thr={thr} n={n}: "
+                    f"max {(ref - got).abs().max().item():.3e}",
+                )
+
+    def test_parity_bf16(self):
+        for thr in (0.3, 0.5):
+            for n in (128, 512, 1500):
+                torch.manual_seed(n)
+                key = torch.randn(1, 4, n, 128, device="cuda", dtype=torch.bfloat16)
+                ref = self.tiled(key, threshold=thr, retain_direction="last")
+                got = self.fused(key, threshold=thr)
+                self.assertTrue(
+                    torch.allclose(ref.float(), got.float(), atol=3e-2, rtol=1e-3),
+                    f"bf16 retain diverged thr={thr} n={n}: "
+                    f"max {(ref.float() - got.float()).abs().max().item():.3e}",
+                )
+
+    def test_no_neighbor_defaults_to_col0(self):
+        # A very high threshold -> no above-threshold neighbours -> retain=col 0
+        # for every row (the reference's default). Must still match tiled.
+        torch.manual_seed(7)
+        key = torch.randn(1, 4, 300, 128, device="cuda", dtype=torch.float32)
+        ref = self.tiled(key, threshold=0.99, retain_direction="last")
+        got = self.fused(key, threshold=0.99)
+        self.assertTrue(torch.allclose(ref, got, atol=5e-4, rtol=1e-3))
+
+    def test_run_to_run_determinism(self):
+        # The retain kernel uses tl.atomic_add, whose FP accumulation order can
+        # vary between launches. Measured (2026-07-11, H100): the resulting score
+        # jitter is negligible — 0.0 for bf16/fp16 (rounded away) and ~1e-10 for
+        # fp32 — and it NEVER flips the top-k kept set, which is the only thing
+        # that could change the model output. This pins both: a regression that
+        # introduced meaningful jitter or an unstable kept set would fail.
+        window, budget = 32, 256
+        for dtype, score_atol in (
+            (torch.bfloat16, 1e-6),
+            (torch.float16, 1e-6),
+            (torch.float32, 1e-6),
+        ):
+            torch.manual_seed(123)
+            key = torch.randn(1, 8, 1024, 128, device="cuda", dtype=dtype)
+            ref = self.fused(key, threshold=0.5).float()
+            ref_kept = (
+                ref[:, :, :-window]
+                .topk(budget - window, dim=-1)
+                .indices.sort(-1)
+                .values
+            )
+            for _ in range(25):
+                got = self.fused(key, threshold=0.5).float()
+                self.assertLessEqual(
+                    (got - ref).abs().max().item(),
+                    score_atol,
+                    f"fused kernel jitter exceeds {score_atol} ({dtype})",
+                )
+                kept = (
+                    got[:, :, :-window]
+                    .topk(budget - window, dim=-1)
+                    .indices.sort(-1)
+                    .values
+                )
+                self.assertTrue(
+                    torch.equal(kept, ref_kept),
+                    f"fused kernel kept-set is nondeterministic ({dtype})",
+                )
+
+
+@unittest.skipUnless(
+    _HAS_CUDA and _HAS_TRITON, "fused redundancy kernel needs CUDA + Triton"
+)
+class TestDecodeR1KVFused(unittest.TestCase):
+    """Decode R1KV._scores must be unchanged when the fused kernel is adopted."""
+
+    @classmethod
+    def setUpClass(cls):
+        mod = _load("rkv_algo", "algo.py")
+        cls.R1KV = mod.R1KV
+        cls.cal_similarity = staticmethod(mod.cal_similarity)
+
+    def _pair(self, budget=64, window=8):
+        kw = dict(
+            budget=budget,
+            window_size=window,
+            kernel_size=7,
+            mix_lambda=0.1,
+            retain_ratio=0.1,
+            retain_direction="last",
+        )
+        fused = self.R1KV(**kw)
+        ref = self.R1KV(**kw)
+        ref._fused_redundancy = False  # force full-matrix cal_similarity
+        return fused, ref
+
+    def test_scores_parity_fp32(self):
+        for n in (128, 512, 1500):
+            torch.manual_seed(n)
+            k = torch.randn(2, 4, n, 128, device="cuda", dtype=torch.float32)
+            q = torch.randn(2, 4, n, 128, device="cuda", dtype=torch.float32)
+            fused, ref = self._pair()
+            sf = fused._scores(k, q)
+            sr = ref._scores(k, q)
+            self.assertTrue(
+                torch.allclose(sf, sr, atol=5e-4, rtol=1e-3),
+                f"decode _scores diverged n={n}: max {(sf - sr).abs().max().item():.3e}",
+            )
+
+    def test_select_indices_parity_fp32(self):
+        # fp32 fused is bit-exact -> identical kept-token selection (incl. GQA).
+        for n in (200, 512, 1500):
+            torch.manual_seed(n + 1)
+            k = torch.randn(1, 4, n, 128, device="cuda", dtype=torch.float32)
+            q = torch.randn(1, 8, n, 128, device="cuda", dtype=torch.float32)
+            fused, ref = self._pair()
+            idx_f = fused.select_indices(k, q, sort=True)
+            idx_r = ref.select_indices(k, q, sort=True)
+            self.assertTrue(
+                torch.equal(idx_f, idx_r), f"decode select_indices differ at n={n}"
+            )
+
+    def test_gate_adopts_fused(self):
+        torch.manual_seed(3)
+        k = torch.randn(2, 4, 300, 128, device="cuda", dtype=torch.float32)
+        q = torch.randn(2, 4, 300, 128, device="cuda", dtype=torch.float32)
+        algo = self.R1KV(
+            budget=64,
+            window_size=8,
+            kernel_size=7,
+            mix_lambda=0.1,
+            retain_ratio=0.1,
+            retain_direction="last",
+        )
+        self.assertIsNone(algo._fused_redundancy)
+        algo._scores(k, q)  # first call runs the smoke gate
+        self.assertIsNotNone(algo._fused_redundancy)
+        self.assertIsNot(algo._fused_redundancy, False)
+
+    def test_reference_redundancy_bounded_memory(self):
+        # The gate's CUDA reference must be the O(n)-memory tiled path, not the
+        # O(n^2) full matrix, which OOMs on long sequences (decode-mode
+        # long-prompt compaction, where n = prompt length).
+        n = 8192
+        torch.manual_seed(0)
+        key = torch.randn(1, 4, n, 128, device="cuda", dtype=torch.bfloat16)
+        algo = self.R1KV(budget=512, window_size=8, retain_direction="last")
+
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        ref = algo._reference_redundancy(key)
+        tiled_gb = torch.cuda.max_memory_allocated() / 1e9
+
+        torch.cuda.empty_cache()
+        torch.cuda.reset_peak_memory_stats()
+        full = self.cal_similarity(key, retain_direction="last")
+        full_gb = torch.cuda.max_memory_allocated() / 1e9
+
+        # O(n) tiled reference uses far less than the O(n^2) full matrix...
+        self.assertLess(
+            tiled_gb,
+            full_gb / 2,
+            f"reference not tiled: {tiled_gb:.2f} GB vs full {full_gb:.2f} GB",
+        )
+        # ...and is still bit-parity with it.
+        self.assertTrue(torch.allclose(ref.float(), full.float(), atol=1e-3, rtol=1e-2))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

This refreshes the `SGLang/` R-KV patch distribution from the earlier **decode-only** port (`@9ed5f084`) to the current **hardened** R-KV source (`wanke1997/sglang-compress @ main`). Both the old and new ports pin the **same** upstream base commit `49e384ce9d304648e9959666ecb8ce8cd98d0deb` (release/v0.5.14), so the wiring stays a clean 1:1 diff and `scripts/apply_rkv.sh` still reproduces a known-good tree.

`18 files changed, +4990 / −387` (commit `3817c305`). Nothing outside `SGLang/` is touched.

Beyond bug-for-bug parity, this brings in six months of work that the old distribution predates: **prefill-phase R-KV**, a **fused Triton redundancy kernel**, **decode CUDA-graph support**, **two-phase compaction**, **compression-aware admission**, **full KV-pool memory accounting**, and **un-bypassable safety guards**.

## Equivalence guarantee (how to trust the patch)

Because the dev fork sits *directly* on the pinned upstream commit with zero unrelated drift, the tree produced by `apply_rkv.sh` (base + `rkv/` + patch) is **byte-identical** to the development source:

- reconstructed `base(49e384ce9) + rkv/ + patch`, then `diff -rq --no-dereference` against the dev `python/sglang/srt` → **empty**;
- all **15** changed files (6 `rkv/` + 9 wiring) match by `sha256`;
- `git apply --check` passes; `apply_rkv.sh` runs clean end-to-end.

## Package changes — `rkv/` (6 files)

| File | Δ | What |
| --- | --- | --- |
| `algo.py` | +154 | pure R1KV scoring/selection; lazy hooks into the fused kernel + tiled reference |
| `integration.py` | +773 | decode compressor: in-graph observation, two-phase compaction, per-request cursor, memory accounting, invariant guards |
| `prefill.py` | **new (482)** | prompt-phase algorithm: `oneshot_keep` / `buffered_keep`, row-blocked `cal_similarity_tiled` (O(n) peak mem) |
| `prefill_integration.py` | **new (644)** | prompt-phase compressor: compress at end of prefill, physical free to `budget`, admission reserve |
| `redundancy_fused.py` | **new (237)** | fused Triton redundancy kernel (row-blocked similarity → mean → softmax, no `n×n` materialization) |
| `__init__.py` | 0 | already identical |

## Wiring patch — 5 → 9 upstream files

`patch/rkv-sglang-0.5.14.patch` (all additive):

| File | +lines | Change |
| --- | --- | --- |
| `server_args.py` | 166 | `--enable-rkv` + per-field flags, `--rkv-config` JSON override, **`--rkv-max-active-requests`**, **`--rkv-fused-validation`**; prefill mode **`--enable-rkv-prefill`** + `--rkv-prefill-config`; `_handle_rkv_validation` / `_handle_rkv_prefill_validation` reject unsafe combos at startup |
| `model_runner.py` | 100 | build `RKVCompressor` / prefill compressor in `alloc_memory_pool`; call `maybe_compact` after the decode forward |
| `model_runner_kv_cache_mixin.py` | 146 | reserve R-KV aux GPU memory (`rolling_q` + compaction workspace) in KV-pool sizing so admission accounting is correct; apply the `--rkv-max-active-requests` cap |
| `schedule_policy.py` | 126 | **compression-aware admission**: `PrefillAdder` reserves the *constant compressed ceiling* `min(prompt, budget)+output` instead of `prompt+output` |
| `scheduler.py` | 120 | re-bind compressor in `init_memory_pools`; `_apply_rkv_pre_decode` before `prepare_for_decode`; `commit_compactions` after the forward (two-phase) |
| `flashinfer_backend.py` | 39 | backend holds the compressor; bind onto the real decode batch in `init_forward_metadata`; `observe_decode_layer` / `observe_prefill_layer` after `set_kv_buffer` |
| `batch_result_processor.py` | 42 | `on_request_end` at the two real-finished points; commit queued frees before the finished-request release loop (no double-free) |
| `forward_batch_info.py` | 16 | restore **logical** rotary positions at `ForwardBatch` construction so eager *and* captured-graph decode read correct positions |
| `schedule_batch.py` | 18 | `on_request_retract` hooks — drop per-request compressor state while `req_pool_idx` is still valid (no stale bookkeeping / KV leak on the next prefill) |

## Optimizations (what makes it fast)

1. **In-graph observation + hybrid CUDA-graph decode.** The observation-window queries are collected *inside* the captured decode graph (fixed-address rolling buffer, per-request GPU step counter); only the `window_size` steps ending at a compaction — plus the compaction step — run eager, everything else replays the graph. **Decode CUDA graph is now supported** (old port was eager-only): **~424 → ~580 tok/s (+37%)** on Math-7B.
2. **Batched cross-layer scoring.** One GEMM pass instead of `num_layers` launches — **8× on a 2174-token prompt**, **+80% decode throughput at `buffer_size=16`**. (On very long prompts the per-layer O(n²) redundancy *compute* dominates, so it’s compute-neutral there — that’s the top remaining roadmap item.)
3. **Fused Triton redundancy kernel + validation gate.** `--rkv-fused-validation {startup,first-request,off}` (default `startup`) validates once at load on a synthetic tensor sized to the real model, so no real request pays the A/B gate; permanent fallback to the reference on any per-call failure. Determinism on H100: jitter `0.0` (bf16/fp16), `~1e-10` (fp32), kept-set never flips.
4. **Host-sync reduction.** `override_decode_positions`: per-request `.item()` (one sync/req/step) → single `.tolist()` + batched scatter. `observe_prefill_layer`: host metadata computed once per forward instead of once per layer (saves `num_layers−1` syncs).
5. **Compression-aware admission** (the throughput unlock in memory-bound regimes): reserves the constant compressed footprint → peak concurrent running-req **10 → 65 (6.5×)**; the edge grows with prompt length (equal-work `--ignore-eos`: even at ~5K, **1.48× at ~20K**).

## Production hardening (what makes it safe)

1. **Memory accounting** — the `rolling_q` observation buffer (~6.1 GiB on a 7B) *and* the transient compaction workspace (~0.6 GiB) are now reserved in KV-pool sizing (were invisible to admission → OOM/graph-capture risk). `--rkv-max-active-requests 128` shrinks `rolling_q` **6.13 → 0.19 GiB**, returning the memory to the KV pool.
2. **Two-phase compaction** — allocator `free()` moved out of the forward stream (root of the overlap race): *prepare* relocates KV in the forward, *commit* frees the tail in the scheduler at a stream-synced point before the finished-request loop.
3. **Per-request rolling-query cursor** — replaces the global circular cursor that could wedge a phantom slot into a request’s observation window if it skipped a decode step.
4. **Un-bypassable invariant guards** — safety `assert`s → explicit `RuntimeError`/`ValueError` (survive `python -O`); the **whole** `req_to_token` slot table is validated 1-to-1 *before* any KV mutation (prevents use-after-free); stale-plan identity guard between prepare and commit.

## New user-facing config

- Decode: `--enable-rkv` (+ `--rkv-budget/window-size/kernel-size/mix-lambda/retain-ratio/retain-direction/buffer-size/min-seq-len`, `--rkv-config`), `--rkv-max-active-requests`, `--rkv-fused-validation`.
- Prefill: `--enable-rkv-prefill` (+ `--rkv-prefill-config`, `mode = oneshot|buffered`); additionally requires `--disable-prefill-cuda-graph`; mutually exclusive with `--enable-rkv`.
- Required for both: `--disable-radix-cache --disable-overlap-schedule --page-size 1`, `tp == 1`. **Decode CUDA graph is supported** (no longer rejected). TP ≥ 2 hard-blocked at startup; plain DP (`--dp-size N --tp-size 1`) validated.

## Tests

`tests/`: refreshed `test_rkv_algo.py` / `test_rkv_integration.py`; added `test_rkv_prefill.py`, `test_rkv_prefill_integration.py`, `test_rkv_redundancy_fused.py`. All load modules by path (no installed `sglang`). **62/62 pass** (algo 7, integration 24, prefill 9, prefill-integration 11, fused 11); `test_cross_repo_parity.py` still **bit-for-bit** vs the repo-root `rkv/` reference across MHA/GQA/batch>1/fp32/bf16.

## Validation (H100)

- **Decode R-KV, Qwen2.5-Math-7B, budget 512, conc 8:** 3× eager runs **19/20 = 0.950** (~232 compactions each, zero crashes/leaks/double-frees); decode-graph-on **18/20** (one-item n=20 noise), **579.6 tok/s (+37%)**, 0 errors.
- **Prefill R-KV, Qwen3-30B-A3B-Thinking (msrv), budget 4096, dp8, GPT-5.2 judge (single pass, 136 prompts):** Full-KV **106/136 = 77.9%**, R-KV(A oneshot) **104/136 = 76.5%**, R-KV(B buffered) **104/136 = 76.5%** — within judge noise (±4 records), i.e. **essentially lossless at budget 4096**.

## Docs

Refreshed `docs/DESIGN.md` + `docs/IMPLEMENTATION.md` (9-file wiring, provenance, decode-graph note); added `docs/OPTIMIZATIONS.md` (optimization + hardening story with measured effects) and `docs/REPRODUCE.md` (exact validated repro). `README.md` / `apply_rkv.sh` / `launch_server.sh` updated (9 files, decode-graph supported, new flags).

## How to review

1. `bash scripts/apply_rkv.sh` → inspect `sglang-src/` (the wiring is exactly `patch/rkv-sglang-0.5.14.patch`).
2. `python3 tests/test_rkv_*.py` (62 tests) + `tests/test_cross_repo_parity.py`.
3. Diff is additive-only against the pinned base; start with `docs/OPTIMIZATIONS.md` for the rationale, then `docs/IMPLEMENTATION.md §7` for the wiring table.