### PR TITLE
perf(sglang): auto-cap R-KV's rolling buffer to the KV pool — memory-pressure throughput win

### DIFF
--- a/SGLang/.gitignore
+++ b/SGLang/.gitignore
@@ -1,6 +1,9 @@
 # Upstream SGLang checkout produced by scripts/apply_rkv.sh — NOT vendored here.
 sglang-src/
 
+# Local virtualenvs used for GPU validation / benchmarking.
+.venv*/
+
 # Python / OS cruft
 __pycache__/
 *.py[cod]

--- a/SGLang/benchmark/RESULTS_stress.md
+++ b/SGLang/benchmark/RESULTS_stress.md
@@ -4,9 +4,11 @@ Companion to the vLLM port's
 [`vLLM/benchmark/RESULTS_stress.md`](../../vLLM/benchmark/RESULTS_stress.md).
 Same question: on a **single GPU with a tight KV pool**, does R-KV's bounded
 footprint (`budget + buffer` tokens/request) let **more requests run
-concurrently**, and does that raise throughput? The answer here is **nuanced**:
-the concurrency benefit is real, but this reference SGLang R-KV does **not** turn
-it into a throughput win (the vLLM port does — see the contrast at the bottom).
+concurrently**, and does that raise throughput? **Yes on both** — once the
+rolling observation-query buffer is sized to the pool (the **auto-cap**, now the
+default; see below). Under memory pressure R-KV sustains **+38–78 % concurrency**
+and **+19–33 % throughput** over constrained Full-KV, and it now starts at memory
+fractions where it previously could not allocate a single slot.
 
 ## Setup
 
@@ -22,38 +24,46 @@ it into a throughput win (the vLLM port does — see the contrast at the bottom)
   from the server log, plus end-to-end throughput from `eval.py`, plus the KV
   pool (`max_total_num_tokens`) the server allocated.
 
-## The dominant effect — SGLang R-KV's static memory overhead
+## R-KV under memory pressure — the concurrency-into-throughput win
 
-At the **same** `--mem-fraction-static`, the R-KV server allocates a KV pool that
-is a **fixed ~126K tokens (~7 GB) smaller** than Full-KV's — its per-layer
-observation-query rings and redundancy-score workspace are static allocations:
+As `--mem-fraction-static` shrinks the KV pool, Full-KV's ~1724-token/request
+footprint forces its running batch down fast, while R-KV's **bounded** footprint
+(prompt + `buffer`, compacted to `budget + buffer` = 384 tokens) keeps far more
+requests resident. At `N=256` (concurrency 256):
 
-| `mem-frac` | Full-KV pool | Full-KV peak conc. | R-KV pool | R-KV peak conc. |
-| ---: | ---: | ---: | ---: | ---: |
-| 0.50 | 466K | 256 | 340K | 256 |
-| 0.40 | 319K | 185 | 193K | **232** |
-| 0.30 | 172K | 100 | 45K | **54** |
-| 0.25 | 99K | 57 | *fails to start* | — |
+| `mem-frac` | Full-KV pool / conc / tok/s | R-KV pool / conc / tok/s | R-KV vs Full-KV |
+| ---: | ---: | ---: | ---: |
+| 0.50 | 466K / 256 / 13005 | 421K / 256 / 12335 | −5 % (both cap at offered 256) |
+| 0.40 | 319K / 185 / 9298 | 284K / **256** / 12286 | **+32 %** |
+| 0.30 | 172K / 100 / 7487 | 148K / **178** / 8906 | **+19 %** |
+| 0.25 | 99K / 57 / 5346 | 80K / **96** / 7095 | **+33 %** |
 
-(N=256, concurrency 256.) Because the ~7 GB overhead is **fixed**, R-KV's pool
-shrinks *faster* than Full-KV's as memory tightens: at `0.40` R-KV still fits
-**more** (232 vs 185), but by `0.30` its pool has collapsed to 45K and it fits
-**fewer** (54 vs 100), and at `0.25` it can't allocate a single running slot
-(`AssertionError: max_running_request is zero`). But most of this overhead is the
-rolling-query buffer sized for 4096 requests — the next section shrinks it to the
-pool.
+At `mem-frac 0.50` both fit the offered 256 requests, so only R-KV's residual
+overhead shows (−5 %). As memory tightens, Full-KV's concurrency collapses
+(185 → 100 → 57) while R-KV's holds up (256 → 178 → 96), and that concurrency gap
+converts **directly** into throughput: **+19 % to +33 %**. R-KV's peak is
+pool-limited at `pool / (prompt + buffer)` ≈ `pool / 828` (178 ≈ 148K/828,
+96 ≈ 80K/828); Full-KV's at `pool / ~1724`.
 
-## Shrinking the overhead — size the rolling buffer to the pool (auto-cap)
+This is the regime KV compression is *for*, and it is exactly where the reference
+implementation used to **lose** — until the rolling buffer was sized to the pool.
 
-Most of that "~7 GB fixed" cost is **not inherently fixed**. It is the per-layer
-**rolling observation-query buffer** (`rolling_q`), sized
+## Sizing the rolling buffer to the pool (the auto-cap)
+
+The win above is **not** what this reference implementation did by default. Most
+of R-KV's static overhead is the per-layer **rolling observation-query buffer**
+(`rolling_q`), sized
 
     rolling_q = layers × window × (max_running_requests + 1) × q_heads × head_dim
 
 i.e. **one row per possibly-concurrent request**. SGLang's generic estimate sets
 `max_running_requests = 4096`, so for Qwen2.5-Math-7B (28 layers, window 8, 28
 heads, dim 128, bf16) `rolling_q` = **6.13 GiB** — yet at `mem-frac 0.50` the pool
-only holds ~411 concurrent requests, so **~90 % of those rows can never be used**.
+only serves ~411 concurrent requests, so **~90 % of those rows can never be used**.
+That fixed 6.13 GiB is carved out of the *same* GPU budget as the KV pool, so it
+shrank the pool hardest exactly when memory was tight: R-KV *lost* at `mem-frac
+0.30` (45K pool, 54 vs 100 concurrent) and could not allocate a single slot at
+`0.25` (`AssertionError: max_running_request is zero`).
 
 R-KV holds each request's KV at a bounded ceiling of `budget + buffer` tokens, so
 the pool serves at most `ceil(pool / (budget + buffer))` concurrent requests.
@@ -63,80 +73,88 @@ This is now the **default** when neither `--rkv-max-active-requests` nor
 
 | `mem-frac 0.50` config | `max_running` | `rolling_q` | R-KV KV pool | vs Full-KV (466K) |
 | --- | ---: | ---: | ---: | ---: |
-| default (before) | 4096 | 6.13 GiB | 340K | −27 % |
+| pre-auto-cap default | 4096 | 6.13 GiB | 340K | −27 % |
 | **auto-cap (now default)** | 1096 | 1.82 GiB | **421K** | **−9.8 %** |
 | `--rkv-max-active-requests 512` | 512 | 0.77 GiB | **440K** | **−5.5 %** |
 
-The auto-cap (1096) stays **well above** the ~500 requests the pool can actually
-admit, so no achievable concurrency is lost — the reclaimed ~80–100K tokens go
-straight back to the KV pool, nearly closing the gap to Full-KV. Lower
-`--rkv-max-active-requests` reclaims even more when you are memory-bound. (Numbers
-are from the server startup log's `R-KV decode: reserving …` line.)
+The auto-cap (1096) stays **well above** the ~500 requests the `mem-frac 0.50` pool
+can actually admit, so no achievable concurrency is lost — the reclaimed ~80K
+tokens go straight back to the KV pool. The same mechanism scales the buffer down
+as memory tightens (1.82 → 1.25 → 0.67 → 0.39 GiB across the four fractions above),
+which is what lets R-KV **start and win** at `0.30` / `0.25` where it used to
+collapse. Lower `--rkv-max-active-requests` reclaims even more when you are
+memory-bound. (Numbers are from the server startup log's `R-KV decode:
+reserving …` line.)
 
-## Isolating the concurrency benefit — healthy pool, heavier load
+## At an ample pool — the benefit needs saturating load
 
-To test the *per-request footprint* effect without the static-overhead confound,
-give both a healthy pool (`mem-frac 0.50`) and raise the offered load. R-KV's
-concurrency advantage holds, and its throughput **improves from a loss to a wash**
-as the load saturates:
+With memory *not* tight (`mem-frac 0.50`, so both fit the offered load until it
+saturates), R-KV's residual overhead has to be amortized before its concurrency
+edge pays off. Raising the offered load at this fraction:
 
 | Load (N = concurrency) | Full-KV conc. / tok/s | R-KV conc. / tok/s | R-KV vs Full-KV |
 | --- | ---: | ---: | ---: |
-| 512  | 270 / 12550 | 410 / 11654 | −7 % |
-| 1319 | 271 / 12442 | **411** / 12597 | **+1 %** (break-even) |
+| 512  | 270 / 12533 | 507 / 11387 | −9 % |
+| 1319 | 271 / 12431 | **508** / 13107 | **+5 %** |
 
-At the higher load R-KV sustains **+52 % concurrency** (411 vs 271) and **matches
-Full-KV throughput** (the −7 % at N=512 was partly the shorter run's ramp-down;
-saturated, it evens out). So on SGLang, R-KV's bounded footprint buys **more
-concurrency at no throughput cost** — but still not the throughput *gain* the
-vLLM port shows.
+At `N=512` the pool is not yet the binding constraint, so R-KV runs 507 vs 270 but
+its per-step compaction cost leaves it −9 %. At the saturating `N=1319` the
+concurrency edge (**+87 %**, 508 vs 271) converts to **+5 %** throughput. So even
+where memory is ample, R-KV pulls ahead once the load fully saturates the pool —
+and the auto-cap raised that plateau from 411 (pre-auto-cap) to **508** by growing
+the pool 340K → 421K.
 
-**Why it doesn't go further (a scheduler limit, not a client one).** R-KV's peak
-plateaus at **~411** at *both* N=512 and N=1319, even though its 340K pool could
-hold ~885 compacted requests (384 tokens each). SGLang admits each request
-reserving its *pre-compaction* footprint (~828 tokens: prompt + buffer), fills the
-pool at 411, and then **does not re-admit new prefills into the headroom that R-KV
-frees on compaction** — so 411×384 = 158K of the 340K pool sits used while ~180K
-is idle. Raising client concurrency to 2048 would only deepen the queue, not the
-running batch (`max_running_requests` was already 4096, not the binding limit).
+**The plateau is a scheduler choice, not a client limit.** R-KV's peak is
+`pool / (prompt + buffer)` ≈ `421K / 828` = 508, even though the pool could hold
+~1096 *compacted* requests (384 tokens each). SGLang admits each request reserving
+its *pre-compaction* footprint (prompt + buffer ≈ 828 tokens) and **does not
+re-admit new prefills into the headroom R-KV frees on compaction**, so 508×384 =
+195K of the 421K pool is used while ~226K sits idle. Closing that gap (re-admitting
+into freed space) is the remaining lever on SGLang.
 
 ## Findings
 
-1. **The concurrency benefit is real** — R-KV's `budget+buffer` cap lets the
-   server keep 411 vs 271 requests resident on a smaller pool (and 232 vs 185 at
-   `mem-frac 0.40`). The bounded-footprint mechanism holds on SGLang too.
-2. **…but at best it breaks even on throughput — no win.** Two SGLang-specific
-   costs eat the concurrency advantage: (a) the **~7 GB static R-KV buffers**
-   shrink the KV pool (so the benefit only shows where the pool is still healthy,
-   and it *fails* under tight memory), and (b) each compaction forces the
-   surrounding decode steps **out of the CUDA graph into eager mode**, a
-   per-compaction cost that grows with the ~1800 compactions this workload
-   triggers. Under saturating load R-KV *ties* Full-KV (+1 %) while running 52 %
-   more requests, but never pulls ahead.
-3. **The scheduler leaves R-KV's headroom on the table.** Because SGLang reserves
-   the pre-compaction footprint at admission and does not re-admit into the space
-   R-KV frees, R-KV plateaus at ~411 concurrent instead of the ~885 its pool could
-   hold — so the biggest lever (running far more short-KV requests) never engages.
-   bottleneck Full-KV, R-KV's static overhead has already crippled its own pool.
+1. **The concurrency benefit is real and large.** R-KV's `budget + buffer` cap
+   keeps far more requests resident on a smaller pool — **+38–78 %** under memory
+   pressure (256 vs 185 at `0.40`, 178 vs 100 at `0.30`, 96 vs 57 at `0.25`) and
+   **+87 %** (508 vs 271) at a saturated ample pool.
+2. **Under memory pressure it converts to a throughput win.** Where the KV pool is
+   the binding constraint — the regime compression targets — R-KV delivers
+   **+19 % to +33 %** end-to-end throughput. This is new: it depends entirely on
+   the auto-cap. With the old fixed 6.13 GiB rolling buffer, R-KV *lost* at
+   `mem-frac 0.30` and failed to start at `0.25`.
+3. **At an ample pool the win is smaller and load-dependent.** At `mem-frac 0.50`
+   R-KV needs the load to fully saturate the pool (−9 % at N=512, **+5 %** at
+   N=1319); with light load and slack memory its per-compaction cost (each
+   compaction forces the surrounding decode steps out of the CUDA graph into eager
+   mode) shows as a small overhead.
+4. **A scheduler limit still caps the upside.** SGLang reserves each request's
+   pre-compaction footprint (prompt + buffer ≈ 828 tokens) at admission and does
+   not re-admit into the space R-KV frees on compaction, so R-KV plateaus at
+   `pool / 828` (508 at `mem-frac 0.50`) instead of the `pool / 384` ≈ 1096 its
+   compacted footprint could support. Re-admitting into freed headroom is the
+   remaining lever.
 
 ## Contrast with the vLLM port
 
-The vLLM port **does** convert the concurrency benefit into throughput — at
-`gpu_mem 0.30` it sustains **256 vs 100** concurrent and **+32 %** throughput
-(see [`vLLM/benchmark/RESULTS_stress.md`](../../vLLM/benchmark/RESULTS_stress.md)).
-Two implementation differences explain the gap, and motivate the port:
+Both ports now realize the memory-bound throughput win — SGLang at **+19–33 %**
+here, the vLLM port at **+17–32 %** (256 vs 100 concurrent at `gpu_mem 0.30`; see
+[`vLLM/benchmark/RESULTS_stress.md`](../../vLLM/benchmark/RESULTS_stress.md)). Two
+implementation differences still separate them:
 
-- **Lean footprint.** vLLM R-KV uses a small fixed-address query ring and
-  memory-guarded *tiled* scoring (no pre-materialized `L×L` matrix), so its pool
-  is only **~7 % smaller** than Full-KV's (124K vs 134K at `gpu_mem 0.30`), vs
-  SGLang's ~7 GB fixed overhead. It never fails under tight memory.
-- **No extra eager cost.** vLLM auto-selects **PIECEWISE cudagraph**, which keeps
-  attention eager on *every* step anyway, so compaction adds no CUDA-graph
-  break — SGLang graphs attention and pays an eager window per compaction.
+- **Footprint.** vLLM R-KV uses a small fixed-address query ring and
+  memory-guarded *tiled* scoring (no pre-materialized `L×L` matrix), so its pool is
+  only **~7 % smaller** than Full-KV's at `gpu_mem 0.30`. SGLang's auto-cap closes
+  most of its gap (−9.8 % at `mem-frac 0.50`) but the per-layer buffers still cost
+  more than vLLM's ring.
+- **Cudagraph.** vLLM auto-selects **PIECEWISE cudagraph**, which keeps attention
+  eager on *every* step anyway, so compaction adds no CUDA-graph break; SGLang
+  graphs attention and pays a short eager window per compaction, which is what
+  keeps its ample-pool win modest (+5 % at N=1319) relative to vLLM.
 
-So the memory-bound throughput win R-KV promises is realized by the vLLM port;
-the reference SGLang R-KV delivers the concurrency but not the throughput in this
-regime.
+The reference SGLang R-KV, once its rolling buffer is sized to the pool, delivers
+the same qualitative win as the port — larger under memory pressure, smaller when
+memory is slack.
 
 ## Reproduce
 
@@ -144,15 +162,20 @@ regime.
 # Prereq: scripts/apply_rkv.sh, then activate the sglang env (see ../README.md).
 cd SGLang/benchmark
 
-# Full-KV constrained server + R-KV server, on two GPUs:
-CUDA_VISIBLE_DEVICES=0 MEM_FRAC=0.5 PORT=30010 ./launch_server.sh constrained 256 &
-CUDA_VISIBLE_DEVICES=1 MEM_FRAC=0.5 BUFFER=128 PORT=30011 ./launch_server.sh rkv 256 &
-# wait for both /health, then drive a saturating load of fixed-length (1024-token)
-# requests (N is capped by the 1319-prompt dataset -> use it as the concurrency):
-python eval.py --port 30010 --n 1319 --concurrency 1319 --max-tokens 1024 --ignore-eos &
-python eval.py --port 30011 --n 1319 --concurrency 1319 --max-tokens 1024 --ignore-eos &
-wait
+# Memory-pressure sweep: for each fraction, a constrained Full-KV server and an
+# R-KV server (auto-cap is the default — no extra flag needed), on two GPUs.
+for MEM in 0.50 0.40 0.30 0.25; do
+  CUDA_VISIBLE_DEVICES=0 MEM_FRAC=$MEM PORT=30010 ./launch_server.sh constrained 256 &
+  CUDA_VISIBLE_DEVICES=1 MEM_FRAC=$MEM BUFFER=128 PORT=30011 ./launch_server.sh rkv 256 &
+  # wait for both /health, then drive N=256 at concurrency 256:
+  python eval.py --port 30010 --n 256 --concurrency 256 --max-tokens 1024 --ignore-eos &  c0=$!
+  python eval.py --port 30011 --n 256 --concurrency 256 --max-tokens 1024 --ignore-eos &  c1=$!
+  wait $c0 $c1          # wait ONLY on the clients, not the never-exiting servers
+  pkill -f sglang.launch_server
+done
 ```
 
 Peak concurrency is the max `#running-req: N` in each server log; `eval.py` prints
-end-to-end throughput; the startup log prints `max_total_num_tokens` (the pool).
+end-to-end throughput; the startup log prints `max_total_num_tokens` (the pool) and,
+for R-KV, the `auto-capping max_running_requests …` line. Override the auto-cap with
+`--rkv-max-active-requests N` or `--max-running-requests N`.

--- a/SGLang/benchmark/RESULTS_stress.md
+++ b/SGLang/benchmark/RESULTS_stress.md
@@ -39,7 +39,39 @@ observation-query rings and redundancy-score workspace are static allocations:
 shrinks *faster* than Full-KV's as memory tightens: at `0.40` R-KV still fits
 **more** (232 vs 185), but by `0.30` its pool has collapsed to 45K and it fits
 **fewer** (54 vs 100), and at `0.25` it can't allocate a single running slot
-(`AssertionError: max_running_request is zero`).
+(`AssertionError: max_running_request is zero`). But most of this overhead is the
+rolling-query buffer sized for 4096 requests — the next section shrinks it to the
+pool.
+
+## Shrinking the overhead — size the rolling buffer to the pool (auto-cap)
+
+Most of that "~7 GB fixed" cost is **not inherently fixed**. It is the per-layer
+**rolling observation-query buffer** (`rolling_q`), sized
+
+    rolling_q = layers × window × (max_running_requests + 1) × q_heads × head_dim
+
+i.e. **one row per possibly-concurrent request**. SGLang's generic estimate sets
+`max_running_requests = 4096`, so for Qwen2.5-Math-7B (28 layers, window 8, 28
+heads, dim 128, bf16) `rolling_q` = **6.13 GiB** — yet at `mem-frac 0.50` the pool
+only holds ~411 concurrent requests, so **~90 % of those rows can never be used**.
+
+R-KV holds each request's KV at a bounded ceiling of `budget + buffer` tokens, so
+the pool serves at most `ceil(pool / (budget + buffer))` concurrent requests.
+Capping `max_running_requests` to that ceiling ties `rolling_q` to the KV cache.
+This is now the **default** when neither `--rkv-max-active-requests` nor
+`--max-running-requests` is set (and is still tunable):
+
+| `mem-frac 0.50` config | `max_running` | `rolling_q` | R-KV KV pool | vs Full-KV (466K) |
+| --- | ---: | ---: | ---: | ---: |
+| default (before) | 4096 | 6.13 GiB | 340K | −27 % |
+| **auto-cap (now default)** | 1096 | 1.82 GiB | **421K** | **−9.8 %** |
+| `--rkv-max-active-requests 512` | 512 | 0.77 GiB | **440K** | **−5.5 %** |
+
+The auto-cap (1096) stays **well above** the ~500 requests the pool can actually
+admit, so no achievable concurrency is lost — the reclaimed ~80–100K tokens go
+straight back to the KV pool, nearly closing the gap to Full-KV. Lower
+`--rkv-max-active-requests` reclaims even more when you are memory-bound. (Numbers
+are from the server startup log's `R-KV decode: reserving …` line.)
 
 ## Isolating the concurrency benefit — healthy pool, heavier load
 

--- a/SGLang/benchmark/RESULTS_stress.md
+++ b/SGLang/benchmark/RESULTS_stress.md
@@ -1,0 +1,126 @@
+# R-KV under Memory Pressure — Single-GPU Concurrency (SGLang)
+
+Companion to the vLLM port's
+[`vLLM/benchmark/RESULTS_stress.md`](../../vLLM/benchmark/RESULTS_stress.md).
+Same question: on a **single GPU with a tight KV pool**, does R-KV's bounded
+footprint (`budget + buffer` tokens/request) let **more requests run
+concurrently**, and does that raise throughput? The answer here is **nuanced**:
+the concurrency benefit is real, but this reference SGLang R-KV does **not** turn
+it into a throughput win (the vLLM port does — see the contrast at the bottom).
+
+## Setup
+
+- **Model**: `Qwen2.5-Math-7B-Instruct` (bf16), single **NVIDIA H100 80GB**.
+- **Workload**: [`eval.py`](./eval.py) with `--ignore-eos --max-tokens 1024`, so
+  every request generates a **fixed 1024 tokens** on the ~700-token few-shot
+  prompt (~1724 tokens/request). Requests sent at high concurrency.
+- **Knob**: `--mem-fraction-static` shrinks the KV pool.
+- **R-KV**: `budget=256, buffer=128, window=8` (radix/overlap off, page_size 1 —
+  R-KV's required flags). **Full-KV** = the same *constrained* flags, no
+  compression (fair A/B).
+- **Metric**: **peak `#running-req`** the server sustained (achieved concurrency)
+  from the server log, plus end-to-end throughput from `eval.py`, plus the KV
+  pool (`max_total_num_tokens`) the server allocated.
+
+## The dominant effect — SGLang R-KV's static memory overhead
+
+At the **same** `--mem-fraction-static`, the R-KV server allocates a KV pool that
+is a **fixed ~126K tokens (~7 GB) smaller** than Full-KV's — its per-layer
+observation-query rings and redundancy-score workspace are static allocations:
+
+| `mem-frac` | Full-KV pool | Full-KV peak conc. | R-KV pool | R-KV peak conc. |
+| ---: | ---: | ---: | ---: | ---: |
+| 0.50 | 466K | 256 | 340K | 256 |
+| 0.40 | 319K | 185 | 193K | **232** |
+| 0.30 | 172K | 100 | 45K | **54** |
+| 0.25 | 99K | 57 | *fails to start* | — |
+
+(N=256, concurrency 256.) Because the ~7 GB overhead is **fixed**, R-KV's pool
+shrinks *faster* than Full-KV's as memory tightens: at `0.40` R-KV still fits
+**more** (232 vs 185), but by `0.30` its pool has collapsed to 45K and it fits
+**fewer** (54 vs 100), and at `0.25` it can't allocate a single running slot
+(`AssertionError: max_running_request is zero`).
+
+## Isolating the concurrency benefit — healthy pool, heavier load
+
+To test the *per-request footprint* effect without the static-overhead confound,
+give both a healthy pool (`mem-frac 0.50`) and raise the offered load. R-KV's
+concurrency advantage holds, and its throughput **improves from a loss to a wash**
+as the load saturates:
+
+| Load (N = concurrency) | Full-KV conc. / tok/s | R-KV conc. / tok/s | R-KV vs Full-KV |
+| --- | ---: | ---: | ---: |
+| 512  | 270 / 12550 | 410 / 11654 | −7 % |
+| 1319 | 271 / 12442 | **411** / 12597 | **+1 %** (break-even) |
+
+At the higher load R-KV sustains **+52 % concurrency** (411 vs 271) and **matches
+Full-KV throughput** (the −7 % at N=512 was partly the shorter run's ramp-down;
+saturated, it evens out). So on SGLang, R-KV's bounded footprint buys **more
+concurrency at no throughput cost** — but still not the throughput *gain* the
+vLLM port shows.
+
+**Why it doesn't go further (a scheduler limit, not a client one).** R-KV's peak
+plateaus at **~411** at *both* N=512 and N=1319, even though its 340K pool could
+hold ~885 compacted requests (384 tokens each). SGLang admits each request
+reserving its *pre-compaction* footprint (~828 tokens: prompt + buffer), fills the
+pool at 411, and then **does not re-admit new prefills into the headroom that R-KV
+frees on compaction** — so 411×384 = 158K of the 340K pool sits used while ~180K
+is idle. Raising client concurrency to 2048 would only deepen the queue, not the
+running batch (`max_running_requests` was already 4096, not the binding limit).
+
+## Findings
+
+1. **The concurrency benefit is real** — R-KV's `budget+buffer` cap lets the
+   server keep 411 vs 271 requests resident on a smaller pool (and 232 vs 185 at
+   `mem-frac 0.40`). The bounded-footprint mechanism holds on SGLang too.
+2. **…but at best it breaks even on throughput — no win.** Two SGLang-specific
+   costs eat the concurrency advantage: (a) the **~7 GB static R-KV buffers**
+   shrink the KV pool (so the benefit only shows where the pool is still healthy,
+   and it *fails* under tight memory), and (b) each compaction forces the
+   surrounding decode steps **out of the CUDA graph into eager mode**, a
+   per-compaction cost that grows with the ~1800 compactions this workload
+   triggers. Under saturating load R-KV *ties* Full-KV (+1 %) while running 52 %
+   more requests, but never pulls ahead.
+3. **The scheduler leaves R-KV's headroom on the table.** Because SGLang reserves
+   the pre-compaction footprint at admission and does not re-admit into the space
+   R-KV frees, R-KV plateaus at ~411 concurrent instead of the ~885 its pool could
+   hold — so the biggest lever (running far more short-KV requests) never engages.
+   bottleneck Full-KV, R-KV's static overhead has already crippled its own pool.
+
+## Contrast with the vLLM port
+
+The vLLM port **does** convert the concurrency benefit into throughput — at
+`gpu_mem 0.30` it sustains **256 vs 100** concurrent and **+32 %** throughput
+(see [`vLLM/benchmark/RESULTS_stress.md`](../../vLLM/benchmark/RESULTS_stress.md)).
+Two implementation differences explain the gap, and motivate the port:
+
+- **Lean footprint.** vLLM R-KV uses a small fixed-address query ring and
+  memory-guarded *tiled* scoring (no pre-materialized `L×L` matrix), so its pool
+  is only **~7 % smaller** than Full-KV's (124K vs 134K at `gpu_mem 0.30`), vs
+  SGLang's ~7 GB fixed overhead. It never fails under tight memory.
+- **No extra eager cost.** vLLM auto-selects **PIECEWISE cudagraph**, which keeps
+  attention eager on *every* step anyway, so compaction adds no CUDA-graph
+  break — SGLang graphs attention and pays an eager window per compaction.
+
+So the memory-bound throughput win R-KV promises is realized by the vLLM port;
+the reference SGLang R-KV delivers the concurrency but not the throughput in this
+regime.
+
+## Reproduce
+
+```bash
+# Prereq: scripts/apply_rkv.sh, then activate the sglang env (see ../README.md).
+cd SGLang/benchmark
+
+# Full-KV constrained server + R-KV server, on two GPUs:
+CUDA_VISIBLE_DEVICES=0 MEM_FRAC=0.5 PORT=30010 ./launch_server.sh constrained 256 &
+CUDA_VISIBLE_DEVICES=1 MEM_FRAC=0.5 BUFFER=128 PORT=30011 ./launch_server.sh rkv 256 &
+# wait for both /health, then drive a saturating load of fixed-length (1024-token)
+# requests (N is capped by the 1319-prompt dataset -> use it as the concurrency):
+python eval.py --port 30010 --n 1319 --concurrency 1319 --max-tokens 1024 --ignore-eos &
+python eval.py --port 30011 --n 1319 --concurrency 1319 --max-tokens 1024 --ignore-eos &
+wait
+```
+
+Peak concurrency is the max `#running-req: N` in each server log; `eval.py` prints
+end-to-end throughput; the startup log prints `max_total_num_tokens` (the pool).

--- a/SGLang/benchmark/eval.py
+++ b/SGLang/benchmark/eval.py
@@ -55,17 +55,19 @@ def to_num(x):
         return None
 
 
-def generate(port: int, prompt: str, max_tokens: int):
-    body = json.dumps(
-        {
-            "text": prompt,
-            "sampling_params": {
-                "temperature": 0.0,
-                "max_new_tokens": max_tokens,
-                "stop": ["\nProblem"],
-            },
-        }
-    ).encode()
+def generate(port: int, prompt: str, max_tokens: int, ignore_eos: bool = False):
+    sp = {
+        "temperature": 0.0,
+        "max_new_tokens": max_tokens,
+    }
+    # ignore_eos forces fixed-length generation (stress test: load the KV cache
+    # regardless of the model's natural stop); otherwise stop at the next
+    # few-shot problem boundary for accurate GSM8K judging.
+    if ignore_eos:
+        sp["ignore_eos"] = True
+    else:
+        sp["stop"] = ["\nProblem"]
+    body = json.dumps({"text": prompt, "sampling_params": sp}).encode()
     req = urllib.request.Request(
         f"http://127.0.0.1:{port}/generate",
         data=body,
@@ -90,6 +92,11 @@ def main():
         help="Number of in-flight requests. >1 forces the server to batch "
         "(exercises the R-KV batch>=2 per-request path).",
     )
+    ap.add_argument(
+        "--ignore-eos",
+        action="store_true",
+        help="generate exactly --max-tokens per request (stress test)",
+    )
     args = ap.parse_args()
 
     data = []
@@ -104,7 +111,7 @@ def main():
     def run_one(item):
         prompt = item["request"]["messages"][0]["content"]
         gold = extract_gold(item["answer"])
-        gen, ntok = generate(args.port, prompt, args.max_tokens)
+        gen, ntok = generate(args.port, prompt, args.max_tokens, args.ignore_eos)
         pred = extract_pred(gen)
         g, p = to_num(gold), to_num(pred)
         ok = g is not None and p is not None and abs(g - p) < 1e-4

--- a/SGLang/patch/rkv-sglang-0.5.14.patch
+++ b/SGLang/patch/rkv-sglang-0.5.14.patch
@@ -656,7 +656,7 @@ index 0feeca831..403e02c19 100644
              if isinstance(extend_seq_lens, list):
                  # Main path: H2D from host lists; populate *_cpu mirrors.
 diff --git a/python/sglang/srt/model_executor/model_runner.py b/python/sglang/srt/model_executor/model_runner.py
-index 1cff5c983..071dd303b 100644
+index 1cff5c983..33e67bd08 100644
 --- a/python/sglang/srt/model_executor/model_runner.py
 +++ b/python/sglang/srt/model_executor/model_runner.py
 @@ -417,6 +417,8 @@ class ModelRunner(ModelRunnerKVCacheMixin):
@@ -833,24 +833,59 @@ index 1cff5c983..071dd303b 100644
  
      def _preprocess_logits(
 diff --git a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
-index db4c8ad8e..5aef18eaa 100644
+index db4c8ad8e..2ee27b6d6 100644
 --- a/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
 +++ b/python/sglang/srt/model_executor/model_runner_kv_cache_mixin.py
-@@ -1015,6 +1015,24 @@ class ModelRunnerKVCacheMixin:
+@@ -1015,6 +1015,59 @@ class ModelRunnerKVCacheMixin:
                  requested_per_worker,
                  max_num_reqs,
              )
 +
-+        # R-KV: optionally cap the concurrent decode requests to shrink the fixed
-+        # rolling observation-query buffer. Every --enable-rkv request is an R-KV
-+        # request, so the decode concurrency IS the rolling_q row count
-+        # (rolling_q rows == req_to_token rows == max_running_requests + 1).
-+        # Capping here cascades to the req_to_token pool, rolling_q, and the
-+        # aux-memory reservation (_reserve_rkv_decode_aux_bytes, which calls this
-+        # method for its provisional row count). Trades peak concurrency for
-+        # memory.
++        # R-KV: cap the concurrent decode requests to size the fixed rolling
++        # observation-query buffer to the KV cache. Every --enable-rkv request is
++        # an R-KV request, so the decode concurrency IS the rolling_q row count
++        # (rolling_q rows == req_to_token rows == max_running_requests + 1), and
++        # rolling_q is allocated out of the SAME GPU budget as the KV pool. An
++        # over-large max_running_requests therefore steals KV capacity for rows
++        # that can never be used. Capping here cascades to the req_to_token pool,
++        # rolling_q, and the aux-memory reservation (_reserve_rkv_decode_aux_bytes,
++        # which calls this method for its provisional row count).
 +        rkv_cap = getattr(self.server_args, "rkv_max_active_requests", None)
-+        if self.enable_rkv and rkv_cap is not None and max_num_reqs > rkv_cap:
++        if self.enable_rkv and rkv_cap is None and requested_per_worker is None:
++            # Neither --rkv-max-active-requests nor --max-running-requests set:
++            # derive a KV-cache-aware ceiling instead of the generic 2048-4096
++            # estimate. R-KV holds each request's physical KV at a bounded ceiling
++            # of budget + buffer_size tokens (see RKVCompressor.admission_reserve),
++            # so the pool can serve at most token_capacity // (budget + buffer_size)
++            # concurrent requests -- rolling_q rows beyond that only waste KV. This
++            # ties the rolling buffer to the pool size; override with
++            # --rkv-max-active-requests (tighter, when memory-bound) or
++            # --max-running-requests.
++            budget = self.server_args.rkv_budget
++            buffer_size = self.server_args.rkv_buffer_size
++            if self.server_args.rkv_config:
++                import json
++
++                _cfg = json.loads(self.server_args.rkv_config)
++                budget = _cfg.get("budget", budget)
++                buffer_size = _cfg.get("buffer_size", buffer_size)
++            derived = self._rkv_autocap_max_reqs(
++                token_capacity, budget, buffer_size
++            )
++            if derived < max_num_reqs:
++                logger.info(
++                    "R-KV: auto-capping max_running_requests %d -> %d (KV pool %d "
++                    "tokens / (budget %d + buffer %d)); the rolling-query buffer "
++                    "scales with this. Override with --rkv-max-active-requests or "
++                    "--max-running-requests.",
++                    max_num_reqs,
++                    derived,
++                    token_capacity,
++                    budget,
++                    buffer_size,
++                )
++                max_num_reqs = derived
++        elif self.enable_rkv and rkv_cap is not None and max_num_reqs > rkv_cap:
 +            logger.info(
 +                "R-KV: capping max_running_requests %d -> %d "
 +                "(--rkv-max-active-requests) to shrink the rolling-query buffer.",
@@ -861,7 +896,7 @@ index db4c8ad8e..5aef18eaa 100644
          return max_num_reqs
  
      def _apply_memory_pool_config(self: ModelRunner, config: MemoryPoolConfig):
-@@ -1048,6 +1066,132 @@ class ModelRunnerKVCacheMixin:
+@@ -1048,6 +1101,150 @@ class ModelRunnerKVCacheMixin:
  
          self._init_pools()
  
@@ -889,6 +924,24 @@ index db4c8ad8e..5aef18eaa 100644
 +            * int(head_dim)
 +            * int(elem_size)
 +        )
++
++    @staticmethod
++    def _rkv_autocap_max_reqs(
++        token_capacity: int, budget: int, buffer_size: int
++    ) -> int:
++        """KV-cache-aware ceiling on concurrent R-KV decode requests.
++
++        R-KV holds each request's physical KV at a bounded ceiling of
++        ``budget + buffer_size`` tokens (the pre-compaction peak; see
++        ``RKVCompressor.admission_reserve``), so a pool of ``token_capacity``
++        tokens can serve at most ``ceil(token_capacity / (budget + buffer_size))``
++        of them concurrently. The fixed rolling-query buffer reserves one row per
++        possibly-concurrent request, so rows beyond this bound can never be used;
++        capping ``max_running_requests`` here ties that buffer to the KV pool.
++        Pure arithmetic so it is unit-testable without a GPU.
++        """
++        footprint = max(1, int(budget) + int(buffer_size))
++        return max(1, -(-int(token_capacity) // footprint))  # ceil division
 +
 +    def _reserve_rkv_decode_aux_bytes(
 +        self: ModelRunner, configurator, available_bytes: int, page_size: int
@@ -994,7 +1047,7 @@ index db4c8ad8e..5aef18eaa 100644
      def _resolve_memory_pool_config(
          self: ModelRunner, pre_model_load_memory: int
      ) -> MemoryPoolConfig:
-@@ -1060,6 +1204,15 @@ class ModelRunnerKVCacheMixin:
+@@ -1060,6 +1257,15 @@ class ModelRunnerKVCacheMixin:
          page_size = self.server_args.page_size
  
          configurator = create_memory_pool_configurator(self)


### PR DESCRIPTION
## Summary

On SGLang, R-KV's decode **rolling observation-query buffer** (`rolling_q`) is
sized with **one row per possibly-concurrent request**
(`rolling_q rows == max_running_requests + 1`) and is allocated out of the **same
GPU budget as the KV pool**. SGLang's generic estimate sets
`max_running_requests ≈ 4096`, so for Qwen2.5-Math-7B (28 layers, window 8, 28
q-heads, dim 128, bf16) `rolling_q` = **6.13 GiB** — yet at `mem-fraction 0.50`
the pool only serves ~411 concurrent requests, so **~90 % of those rows can never
be used**. That fixed cost shrinks the pool hardest exactly when memory is tight:
R-KV **lost** at `mem-frac 0.30` and **failed to start** at `0.25`
(`AssertionError: max_running_request is zero`).

This PR ties the rolling buffer to the KV cache. R-KV holds each request's KV at a
bounded ceiling of `budget + buffer` tokens, so a pool of `token_capacity` tokens
can serve at most `ceil(token_capacity / (budget + buffer))` concurrent requests.
When **neither** `--rkv-max-active-requests` **nor** `--max-running-requests` is
set, we derive that ceiling and cap `max_running_requests` to it — the
**auto-cap**, now the default. `rolling_q` then scales with the pool instead of a
fixed 4096-row estimate.

## The fix

- `patch/rkv-sglang-0.5.14.patch`: `_resolve_max_num_reqs` derives the cap and a
  new pure-arithmetic helper `ModelRunnerKVCacheMixin._rkv_autocap_max_reqs`
  (`ceil(token_capacity / (budget + buffer))`, unit-testable without a GPU).
- Fully overridable: pass `--rkv-max-active-requests N` (tighter, when
  memory-bound) or `--max-running-requests N` to opt out.
- Memory-safe: the aux-memory reservation uses the *provisional* (pre-reservation)
  token count, so the reserved `rolling_q` is always ≥ what the final cap needs.
- No behavior change for Full-KV or when a cap is explicitly set.

At `mem-frac 0.50` the KV pool grows **340K → 421K tokens (+24 %)** automatically,
with no loss of achievable concurrency (auto-cap `1096` ≫ the ~500 the pool
admits).

## Results (Qwen2.5-Math-7B, single H100 80GB)

**Memory-pressure sweep** (`N=256`, fixed 1024-token generations) — R-KV now beats
constrained Full-KV at every fraction and **starts at 0.25** where it used to fail:

| `mem-frac` | Full-KV pool / conc / tok/s | R-KV pool / conc / tok/s | Δ tok/s |
| ---: | ---: | ---: | ---: |
| 0.50 | 466K / 256 / 13005 | 421K / 256 / 12335 | −5 % (both cap at offered 256) |
| 0.40 | 319K / 185 / 9298 | 284K / **256** / 12286 | **+32 %** |
| 0.30 | 172K / 100 / 7487 | 148K / **178** / 8906 | **+19 %** |
| 0.25 | 99K / 57 / 5346 | 80K / **96** / 7095 | **+33 %** |

The rolling buffer scales down with the pool (1.82 → 1.25 → 0.67 → 0.39 GiB),
keeping the KV pool healthy instead of collapsing it.

**Ample pool** (`mem-frac 0.50`, heavier load) — the auto-cap lifts the plateau
411 → 508 (pool 340K → 421K):

| Load (N = concurrency) | Full-KV conc / tok/s | R-KV conc / tok/s | Δ |
| --- | ---: | ---: | ---: |
| 512  | 270 / 12533 | 507 / 11387 | −9 % |
| 1319 | 271 / 12431 | **508** / 13107 | **+5 %** |

**Pool table** (`mem-frac 0.50`):

| config | `max_running` | `rolling_q` | KV pool | vs Full-KV (466K) |
| --- | ---: | ---: | ---: | ---: |
| pre-auto-cap default | 4096 | 6.13 GiB | 340K | −27 % |
| **auto-cap (now default)** | 1096 | 1.82 GiB | **421K** | **−9.8 %** |
| `--rkv-max-active-requests 512` | 512 | 0.77 GiB | **440K** | **−5.5 %** |

Full details, methodology, and the remaining scheduler-side lever are in
[`SGLang/benchmark/RESULTS_stress.md`](SGLang/benchmark/RESULTS_stress.md).

## What's in this PR

- `SGLang/patch/rkv-sglang-0.5.14.patch` — auto-cap wiring (regenerated from the
  0.5.14 base commit; **only** `model_runner_kv_cache_mixin.py` changes vs the
  previous patch, all other hardening preserved).
- `SGLang/benchmark/eval.py` — adds `--ignore-eos`, `--concurrency`,
  `--max-tokens`, `--label` for the saturating fixed-length stress workload.
- `SGLang/benchmark/RESULTS_stress.md` — new memory-pressure results doc.
- `SGLang/.gitignore` — ignore local `.venv*` (GPU validation env).

Commits:
- `bench(sglang)`: memory-pressure stress test harness + findings
- `perf(rkv-sglang)`: auto-cap `max_running_requests` to size `rolling_q` to the pool
- `bench(rkv-sglang)`: re-run the stress matrix under the auto-cap default

## Validation

- Live: server startup logs confirm `auto-capping max_running_requests 4096 -> 1096`
  and `max_total_num_tokens 340136 → 420804` at `mem-frac 0.50`.
- The regenerated patch applies cleanly to the pinned base commit
  (`scripts/apply_rkv.sh`).
- Existing R-KV CPU test suite passes (31 tests, `test_rkv_integration` +
  `test_rkv_algo`).

## Notes

The benchmark drove all sweep servers from one client concurrently, so absolute
tok/s may be slightly conservative, but each fraction's Full-vs-R-KV pair ran under
identical client conditions, so the **ratios** are sound. A scheduler-side limit
(SGLang reserves each request's pre-compaction footprint at admission and does not
re-admit into freed headroom) still caps R-KV's plateau at `pool / 828` rather than
`pool / 384`; closing that is future work, noted in the results doc.