### PR TITLE
test(smoke): refresh vLLM + SGLang smokes for the current ports

### DIFF
--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -8,19 +8,21 @@ catches the two classic KV-corruption signatures: token salad (e.g.
 0 = pass. Set `RKV_SMOKE_MODEL` to override the model.
 
 Each integration needs its own environment — the stacks pin conflicting
-torch/transformers versions (see the per-tree requirements). The first
-five were validated on A100-40GB (sm80), CUDA 12.4-12.6 wheels,
-Python 3.10, at repo `main`. `flashinfer_smoke.py` targets the newer
-Python 3.12 / CUDA 12.8 / torch 2.10 stack pinned in
+torch/transformers versions (see the per-tree requirements). The vLLM
+(v0.25.1) and SGLang (v0.5.14) smokes build their current *patch-style* ports
+via `scripts/apply_rkv.sh` (see each port's `docs/OPTIMIZATIONS.md`); the
+Nano-vLLM, Mini-SGLang and HuggingFace smokes were validated on A100-40GB
+(sm80), CUDA 12.4-12.6 wheels, Python 3.10. `flashinfer_smoke.py` targets the
+newer Python 3.12 / CUDA 12.8 / torch 2.10 stack pinned in
 `FlashInfer/requirements-rkv.txt`; its FA3 option additionally needs the
 hopper `flash_attn_interface` build on SM90:
 
 | Script | Env | Model (default) | R-KV switch |
 |---|---|---|---|
-| `vllm_smoke.py` | `pip install vllm==0.8.5 transformers==4.51.3`, then overlay the whole checked-in `vLLM/vllm/` package onto site-packages | Qwen/Qwen3-0.6B | `VLLM_USE_V1=1 VLLM_V1_R_KV_BUDGET=64 VLLM_V1_R_KV_BUFFER=8` (`BUFFER=0` disables; backend must be FLASH_ATTN) |
+| `vllm_smoke.py` | `cd vLLM && scripts/apply_rkv.sh`, then `pip install -e vllm-src` (v0.25.1 patch-style port) | Qwen/Qwen3-0.6B | `VLLM_V1_R_KV_BUDGET=64 VLLM_V1_R_KV_BUFFER=8` (set **both** to `0` to disable — the port requires both-or-neither; backend must be FLASH_ATTN; PIECEWISE cudagraph is the default — no enforce_eager); asserts physical compaction fired |
 | `nano_smoke.py` | `pip install -e Nano-vLLM` + flash-attn>=2.5 (model path must be a **local directory**) | Qwen/Qwen3-0.6B | `RKV_ON=1` -> `rkv_enabled=True, rkv_budget=256, rkv_buffer=32` |
 | `minisgl_smoke.py` | `cd Mini-SGLang && scripts/apply_rkv.sh`, then `pip install -e mini-sglang-src` | Qwen/Qwen3-0.6B | `RKV_ON=1` -> `rkv_enabled=True, rkv_budget=512, rkv_buffer=64`; instruments `RKVCompressor.maybe_compress` and fails if compression never fires |
-| `sglang_smoke.py` | `cd SGLang && scripts/apply_rkv.sh`, then `pip install -r requirements-rkv.txt && pip install -e sglang-src/python` | Qwen/Qwen2.5-0.5B-Instruct | `RKV_ON=1` -> `enable_rkv=True, rkv_budget=128`, FlashInfer, radix/cuda-graph/overlap off, `page_size=1`; `BATCH=2` for the batch variant |
+| `sglang_smoke.py` | `cd SGLang && scripts/apply_rkv.sh`, then `pip install -r requirements-rkv.txt && pip install -e sglang-src/python` | Qwen/Qwen2.5-0.5B-Instruct | `RKV_ON=1` -> `enable_rkv=True, rkv_budget=128`, FlashInfer, radix/overlap off, `page_size=1`, **CUDA-graph decode on** (now supported); `BATCH=2` for the batch variant |
 | `hf_smoke.py` | `pip install -e HuggingFace` + flash-attn (transformers must be `>=4.48.1,<4.56`) | deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | `MODE=rkv` (monkeypatch) vs `MODE=fullkv` (stock forward) |
 | `flashinfer_smoke.py` | `pip install -r FlashInfer/requirements-rkv.txt` (standalone engine, no upstream checkout to patch) | Qwen/Qwen3-0.6B | `RKV_ON=1` -> `RKVConfig(budget=64, buffer=16, window_size=8)` (override via `RKV_SMOKE_BUDGET`/`RKV_SMOKE_BUFFER`); reads `GenOutput.num_compactions` and fails if compression never fires |
 | `fa3_parity.py` | FlashInfer env + hopper `flash_attn_interface`, H100/SM90 | local model path | teacher-forced FA3-vs-FlashInfer logits probe over ragged prefill, non-contiguous active rows, and R-KV compaction |
@@ -28,8 +30,8 @@ hopper `flash_attn_interface` build on SM90:
 Usage examples:
 
 ```bash
-# vLLM
-VLLM_USE_V1=1 VLLM_V1_R_KV_BUDGET=64 VLLM_V1_R_KV_BUFFER=8 \
+# vLLM (v0.25.1 patch-style; PIECEWISE cudagraph default, no enforce_eager)
+VLLM_V1_R_KV_BUDGET=64 VLLM_V1_R_KV_BUFFER=8 \
 VLLM_ATTENTION_BACKEND=FLASH_ATTN python tests/smoke/vllm_smoke.py
 
 # Mini-SGLang (R-KV on, then baseline)
@@ -63,6 +65,8 @@ Notes:
   R-KV, which would look like a compression failure.
 - The Mini-SGLang engine force-disables CUDA graph capture when
   `rkv_enabled=True`; graph replay would silently skip the compression
-  hooks (`cuda_graph_max_bs=None` means auto-enable, not disable).
+  hooks (`cuda_graph_max_bs=None` means auto-enable, not disable). The full
+  **SGLang** port, by contrast, gathers observation queries *inside* the
+  captured decode graph, so `sglang_smoke.py` runs with CUDA graphs on.
 - Mini-SGLang and Nano-vLLM both bind hardcoded localhost rendezvous
   ports (2333); do not run their smokes concurrently on one host.

--- a/tests/smoke/sglang_smoke.py
+++ b/tests/smoke/sglang_smoke.py
@@ -1,7 +1,9 @@
-"""SGLang (v0.5.14 port) R-KV smoke: Qwen2.5-0.5B-Instruct, FlashInfer
-backend, eager decode. R-KV requires radix cache / cuda graph / overlap off and
-page_size=1 (enforced at startup). Toggle with RKV_ON=0/1; BATCH=1/2.
-Needs a __main__ guard: sglang launches subprocesses via mp spawn."""
+"""SGLang (v0.5.14 port) R-KV smoke: Qwen2.5-0.5B-Instruct, FlashInfer backend.
+R-KV requires radix cache / overlap off and page_size=1 (enforced at startup),
+but CUDA-graph decode is now SUPPORTED and on by default — the port gathers the
+observation queries *inside* the captured decode graph — so this smoke runs the
+default graphed path. Toggle with RKV_ON=0/1; BATCH=1/2. Needs a __main__ guard:
+sglang launches subprocesses via mp spawn."""
 import os
 import sys
 import time
@@ -25,9 +27,10 @@ def main():
         dtype="bfloat16",
         attention_backend="flashinfer",
         mem_fraction_static=0.25,
-        disable_cuda_graph=True,
-        # R-KV frees KV slots mid-generation; these are required (enforced by
-        # the port's ServerArgs validation) and eager-only.
+        # R-KV frees KV slots mid-generation; these are required (enforced by the
+        # port's ServerArgs validation). CUDA-graph decode is now supported and on
+        # by default — the port gathers observation queries inside the captured
+        # graph, so we no longer disable it.
         disable_radix_cache=True,
         disable_overlap_schedule=True,
         page_size=1,

--- a/tests/smoke/vllm_smoke.py
+++ b/tests/smoke/vllm_smoke.py
@@ -1,7 +1,13 @@
 """vLLM R-KV smoke: Qwen3-0.6B, V1 engine, FLASH_ATTN backend.
 
-R-KV is switched on/off via VLLM_V1_R_KV_BUFFER (0 disables).
-Run under envs/vllm with the checked-in vLLM/vllm package overlaid.
+R-KV is on when VLLM_V1_R_KV_BUDGET and VLLM_V1_R_KV_BUFFER are both > 0 (the port
+requires both-or-neither); set both to 0 (or unset) to disable. Build the v0.25.1
+patch-style port first (``cd vLLM && scripts/apply_rkv.sh && pip install -e
+vllm-src``). Do NOT force enforce_eager — the port auto-selects PIECEWISE cudagraph
+(attention stays eager so the R-KV hooks fire), which is the default this smoke
+exercises. When R-KV is on it also asserts that physical compaction actually
+fired (read from every worker via collective_rpc), so a silently-Full-KV build
+fails instead of passing the lexical check.
 """
 import os
 import sys
@@ -12,8 +18,32 @@ from health_check import report
 
 MODEL = os.environ.get("RKV_SMOKE_MODEL", "Qwen/Qwen3-0.6B")
 
+# read_compactions() below sends a closure to every worker via collective_rpc;
+# vLLM 0.25.1 refuses to serialize a callable across the engine-core process
+# boundary unless this is set (mirrors vLLM/benchmark/eval.py). Must precede the
+# vllm import.
+os.environ.setdefault("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
 from transformers import AutoTokenizer  # noqa: E402
 from vllm import LLM, SamplingParams  # noqa: E402
+
+
+def read_compactions(llm):
+    """Max physical R-KV compactions across TP ranks, read from every worker's
+    compactor via collective_rpc (mirrors vLLM/benchmark/eval.py). Returns None
+    when unavailable — lets the smoke fail a build that silently ran Full-KV."""
+
+    def _get(self):
+        mr = getattr(self, "model_runner", None)
+        comp = getattr(mr, "rkv_compactor", None)
+        return int(getattr(comp, "_n_compactions", 0)) if comp is not None else 0
+
+    try:
+        counts = llm.collective_rpc(_get)
+        return max(counts) if counts else 0
+    except Exception:
+        return None
+
 
 prompts = [
     "Hello, my name is",
@@ -32,8 +62,9 @@ sampling_params = SamplingParams(
 t0 = time.time()
 llm = LLM(
     model=MODEL,
-    enforce_eager=True,
-    enable_prefix_caching=False,
+    # No enforce_eager: the v0.25.1 port auto-selects PIECEWISE cudagraph (attention
+    # stays eager so the R-KV hooks still fire) — that is the default path to smoke.
+    enable_prefix_caching=False,  # R-KV frees KV slots the prefix cache would reference
     gpu_memory_utilization=0.55,
 )
 load_s = time.time() - t0
@@ -50,6 +81,17 @@ for i, output in enumerate(outputs):
     print(f"Prompt: {output.prompt!r}")
     print(f"Output({len(text)} chars): {text[:600]!r}")
     all_ok &= report(f"vllm[{tag}] prompt{i}", text)
+
+# When R-KV is on, prove physical compaction actually fired — otherwise a build
+# that silently runs Full-KV would still pass the lexical health check.
+rkv_on = (int(os.environ.get("VLLM_V1_R_KV_BUDGET", "0") or 0) > 0
+          and int(os.environ.get("VLLM_V1_R_KV_BUFFER", "0") or 0) > 0)
+if rkv_on:
+    n_comp = read_compactions(llm)
+    print(f"RKV_COMPACTIONS {n_comp}")
+    if not n_comp:
+        print("RKV_NEVER_COMPACTED")
+        all_ok = False
 
 print(f"LOAD_SECONDS {load_s:.3f}")
 print(f"GENERATE_SECONDS {gen_s:.3f}")


### PR DESCRIPTION
The serving ports moved on but the smokes did not. GPU-validated on H100 with Qwen2.5-0.5B-Instruct (vLLM R-KV on: 137 compactions, PASS; R-KV off: PASS; SGLang R-KV on with CUDA graphs: PASS).

vLLM (vllm_smoke.py):
- Old setup was unrunnable: it assumed vllm==0.8.5 + overlay-vLLM/vllm/. The port is now v0.25.1 patch-style (scripts/apply_rkv.sh + pip install -e vllm-src).
- Dropped hardcoded enforce_eager=True; the port's default is PIECEWISE cudagraph (attention stays eager so the hooks fire). Confirmed graphs capture + coherent output.
- Added a compaction assertion via collective_rpc (mirrors eval.py's read_compactions) so a silently-Full-KV build fails. Running it surfaced two real gaps the static check missed: (a) vLLM 0.25.1 needs VLLM_ALLOW_INSECURE_SERIALIZATION=1 to ship the closure to the workers (eval.py sets it; the smoke now does too); (b) 'BUFFER=0 disables' is stale — the port requires budget/buffer both-zero-or-both-positive, so disable = set both to 0.

SGLang (sglang_smoke.py):
- Removed disable_cuda_graph=True and the 'cuda-graph off, enforced at startup' docstring: the port now runs in-graph / hybrid CUDA-graph decode as the default fastest path. radix/overlap off + page_size=1 are still required. Runs graphed and passes.

README: fixed the vLLM env row + usage (patch-style, no enforce_eager, both-zero disable, asserts compaction), the SGLang row (cuda-graph on), and the validation note.

Mini-SGLang smoke unchanged: its imports (minisgl.rkv.integration.RKVCompressor) and cuda_graph_max_bs=0 still match the maintained Mini-SGLang benchmark (it force-disables graphs with rkv), so it is already current.